### PR TITLE
fix(release): stop example versions blocking the 0.5.0 bump

### DIFF
--- a/.github/workflows/container-republish.yml
+++ b/.github/workflows/container-republish.yml
@@ -36,7 +36,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: 'A released version, without the leading v (e.g. 0.5.0)'
+        description: 'A released version, without the leading v, as MAJOR.MINOR.PATCH'
         required: true
         type: string
 
@@ -79,7 +79,7 @@ jobs:
         run: |
           set -euo pipefail
           if ! printf '%s' "${VERSION}" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$'; then
-            echo "::error::'${VERSION}' is not a version. Write 0.5.0 or 0.5.0-rc.1 — no leading v."
+            echo "::error::'${VERSION}' is not a version. Write it as MAJOR.MINOR.PATCH or MAJOR.MINOR.PATCH-rc.N — no leading v."
             exit 1
           fi
           echo "Repairing the container image for v${VERSION}."

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -14,7 +14,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: 'Version to release, e.g. 0.5.0 or 0.5.0-rc.1'
+        description: 'Version to release, as MAJOR.MINOR.PATCH or MAJOR.MINOR.PATCH-rc.N'
         required: true
         type: string
       dry_run:

--- a/scripts/container-check-anonymous.ts
+++ b/scripts/container-check-anonymous.ts
@@ -4,7 +4,7 @@
  *
  *   node scripts/container-check-anonymous.ts \
  *     --image docker.io/looptroopai/looptroop \
- *     --version 0.5.0 --index-digest sha256:<index>
+ *     --version 9.9.9 --index-digest sha256:<index>
  *
  * That is the point of it. A private repository is inspectable by the account
  * that pushed to it and by nobody else, so an authenticated check would pass

--- a/scripts/container-manifest.ts
+++ b/scripts/container-manifest.ts
@@ -4,7 +4,7 @@
  * manifests a build already pushed by digest.
  *
  *   node scripts/container-manifest.ts \
- *     --version 0.5.0 --dist-tag latest --revision <commit> \
+ *     --version 9.9.9 --dist-tag latest --revision <commit> \
  *     --image docker.io/looptroopai/looptroop \
  *     --image ghcr.io/looptroop-ai/looptroop \
  *     --digest sha256:<amd64> --digest sha256:<arm64>

--- a/scripts/container-tags.ts
+++ b/scripts/container-tags.ts
@@ -90,8 +90,8 @@ export function planTags(version: string, distTag: string): TagPlan {
  * A release is publishing the newest thing there is, so every floating tag it
  * plans is one it should move. A repair is not: it is republishing a version
  * that may be years behind, and the plan above would have it take `latest` and
- * the series back with it — a repair of 0.5.0 after 0.8.0 shipped would make
- * `docker pull looptroopai/looptroop` serve 0.5.0 again. So a repair names
+ * the series back with it — repairing an old version after a newer one shipped
+ * would make `docker pull looptroopai/looptroop` serve the old one again. So a repair names
  * exactly which floating tags it has evidence for, and every one it does not
  * name moves from "write it" to "prove it did not move".
  *

--- a/scripts/container-verify-pull.ts
+++ b/scripts/container-verify-pull.ts
@@ -5,7 +5,7 @@
  *
  *   node scripts/container-verify-pull.ts \
  *     --image ghcr.io/looptroop-ai/looptroop \
- *     --version 0.5.0 --arch amd64 --expect-digest sha256:<amd64 manifest>
+ *     --version 9.9.9 --arch amd64 --expect-digest sha256:<amd64 manifest>
  *
  * By tag rather than by the digest being asserted, because the tag is the thing
  * that could be wrong. Checking the index first is what makes pulling the tag a

--- a/scripts/release-bump.ts
+++ b/scripts/release-bump.ts
@@ -2,8 +2,8 @@
 /**
  * Writes one release version into every file that must agree on it.
  *
- *   npm run release:bump -- 0.5.0
- *   npm run release:bump -- 0.5.0-rc.1 --dry-run
+ *   npm run release:bump -- 9.9.9
+ *   npm run release:bump -- 9.9.9-rc.1 --dry-run
  *
  * Four files, because `scripts/verify-version-single-source.mjs` is a required
  * check on the release pull request and reads all of them:

--- a/scripts/release-container-notes.ts
+++ b/scripts/release-container-notes.ts
@@ -3,7 +3,7 @@
  * Puts the container pull commands into a release's notes.
  *
  *   node scripts/release-container-notes.ts \
- *     --version 0.5.0 --index-digest sha256:<index> \
+ *     --version 9.9.9 --index-digest sha256:<index> \
  *     --dh-image docker.io/looptroopai/looptroop \
  *     --ghcr-image ghcr.io/looptroop-ai/looptroop \
  *     --in body.md --out body-next.md

--- a/scripts/release-manifest.ts
+++ b/scripts/release-manifest.ts
@@ -2,7 +2,7 @@
 /**
  * Records exactly which bytes a release is made of.
  *
- *   npm run release:manifest -- looptroop-0.5.0.tgz
+ *   npm run release:manifest -- looptroop-9.9.9.tgz
  *
  * The tarball is packed once and then travels between jobs, machines and
  * platforms as an artifact. Every job that consumes it recomputes these hashes

--- a/scripts/release-state.ts
+++ b/scripts/release-state.ts
@@ -16,7 +16,7 @@
 
 /** What the release workflow can observe about one version. */
 export interface ReleaseFacts {
-  /** Version under release, e.g. `0.5.0` or `0.5.0-rc.1`. */
+  /** Version under release, e.g. `9.9.9` or `9.9.9-rc.1`. */
   version: string
   /** The version in package.json at the commit being released. */
   manifestVersion: string

--- a/scripts/release-verify-artifact.ts
+++ b/scripts/release-verify-artifact.ts
@@ -2,7 +2,7 @@
 /**
  * Refuses a tarball whose bytes are not the ones the build produced.
  *
- *   npm run release:verify-artifact -- looptroop-0.5.0.tgz release-manifest.json
+ *   npm run release:verify-artifact -- looptroop-9.9.9.tgz release-manifest.json
  *
  * Run at the top of every job that receives the tarball as an artifact, before
  * installing or publishing it. Comparing only after publishing would prove what

--- a/scripts/smoke-container.mjs
+++ b/scripts/smoke-container.mjs
@@ -12,7 +12,7 @@
  * gets a graceful exit rather than a SIGKILL.
  *
  *   node scripts/smoke-container.mjs --image looptroop:smoke
- *   node scripts/smoke-container.mjs --image ghcr.io/…/looptroop@sha256:… --version 0.5.0
+ *   node scripts/smoke-container.mjs --image ghcr.io/…/looptroop@sha256:… --version 9.9.9
  *
  * Everything runs inside the container, over `docker exec`. Nothing is requested
  * from the host: the daemon binds the container's own loopback on purpose, so a

--- a/scripts/verify-version-single-source.mjs
+++ b/scripts/verify-version-single-source.mjs
@@ -41,6 +41,15 @@ const ALLOWED_PATHS = [
   // including every other test.
   'tests/releaseState.test.ts',
   'tests/versionBump.test.ts',
+  // Fixtures for the container tag rules and the release-notes splice, for the
+  // same reason. A case proving that a prerelease must not take `latest`, or
+  // that a repair must not drag the series backwards, has to name the versions
+  // on both sides of the comparison; a case proving the notes carry the right
+  // pull command has to name the version being published. None of them is a
+  // reference to the version this package is on, and a bump must not turn a
+  // fixture into a release blocker.
+  'tests/containerTags.test.ts',
+  'tests/containerNotes.test.ts',
 ]
 
 /** Files excluded from scanning entirely: binary, generated, or dependency trees. */

--- a/scripts/version-bump.ts
+++ b/scripts/version-bump.ts
@@ -38,7 +38,7 @@ const VERSION_PATTERN = /^(\d+)\.(\d+)\.(\d+)(?:-rc\.(\d+))?$/
 /**
  * Numeric identifiers must not carry a leading zero.
  *
- * npm accepts `0.5.0-rc.01` as a string but semver does not define it, so it
+ * npm accepts `9.9.9-rc.01` as a string but semver does not define it, so it
  * sorts unpredictably against `rc.1` and `rc.2`. Two publishes later the
  * ordering the `next` dist-tag implies stops matching the ordering users see.
  */
@@ -55,7 +55,7 @@ export function parseVersion(value: string): ParsedVersion {
   if (!match) {
     throw new Error(
       `Version "${value}" is not MAJOR.MINOR.PATCH or MAJOR.MINOR.PATCH-rc.N. `
-      + 'Write 0.5.0 or 0.5.0-rc.1 — no leading "v", no other prerelease names.',
+      + 'No leading "v", and no prerelease name other than -rc.N.',
     )
   }
 


### PR DESCRIPTION
The 0.5.0 bump failed on `verify:version` with 49 hits, none of them stale references — they were **example** versions: script usage blocks, two workflow input descriptions, the example inside the "not a version" error message, and container test fixtures.

`0.5.0` was the natural placeholder to write while the project sat on 0.4.1, so it is what everything illustrates itself with. The check cannot tell an illustration from a reference. This was waiting for whichever release matched first — `release-pr.yml`, `release-bump.ts`, `release-state.ts` and `version-bump.ts` have carried it since before the container work.

- Test fixtures join the existing allowlist, whose stated reason already covers them: literals that are inputs to the function under test, not references to the shipped version.
- Everything else stops naming a reachable version: usage blocks use `9.9.9`; the user-facing messages and workflow descriptions give the shape (`MAJOR.MINOR.PATCH or MAJOR.MINOR.PATCH-rc.N`) instead of an example, which is what they already spelled out anyway and can never go stale.

Verified by running the real bump to 0.5.0 and then the real check: 859 files, pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)