### PR TITLE
chore(container): assert GHCR serves releases anonymously too

### DIFF
--- a/.github/workflows/container-republish.yml
+++ b/.github/workflows/container-republish.yml
@@ -495,18 +495,19 @@ jobs:
         with:
           node-version: 24.15.0
 
-      # Add a second invocation with `--image "${GHCR_IMAGE}"` once the GHCR
-      # package has been made public by hand; see release.yml for why it is not
-      # here yet.
-      - name: Docker Hub serves the release anonymously
+      # Both registries; see release.yml for why this is anonymous.
+      - name: Both registries serve the release anonymously
         env:
           VERSION: ${{ needs.prepare.outputs.version }}
           INDEX_DIGEST: ${{ needs.manifest.outputs.index_digest }}
         run: |
-          node scripts/container-check-anonymous.ts \
-            --image "${DH_IMAGE}" \
-            --version "${VERSION}" \
-            --index-digest "${INDEX_DIGEST}"
+          set -euo pipefail
+          for image in "${DH_IMAGE}" "${GHCR_IMAGE}"; do
+            node scripts/container-check-anonymous.ts \
+              --image "${image}" \
+              --version "${VERSION}" \
+              --index-digest "${INDEX_DIGEST}"
+          done
 
       - name: Log in to GHCR
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1248,21 +1248,24 @@ jobs:
       # registry first, retries a rate limit and nothing else, and compares what
       # an anonymous client is served against the index this release published.
       #
-      # GHCR is absent from this list on purpose. GHCR packages are private by
-      # default and do not inherit the repository's visibility, so this check
-      # cannot pass there until someone makes the package public — a one-way
-      # change, done by hand, once, after the first release creates the package.
-      # Adding a second `--image "${GHCR_IMAGE}"` invocation below is all that
-      # enabling it takes.
-      - name: Docker Hub serves the release anonymously
+      # Both registries, because both are documented in the README and a private
+      # one fails every `docker pull` a user copies from it. GHCR packages are
+      # private by default and do not inherit the repository's visibility; this
+      # one was made public by hand after 0.5.0 created it, and this step is what
+      # keeps it that way — flipping it back private now fails the release
+      # instead of quietly breaking half the install instructions.
+      - name: Both registries serve the release anonymously
         env:
           VERSION: ${{ needs.detect.outputs.version }}
           INDEX_DIGEST: ${{ needs.container-manifest.outputs.index_digest }}
         run: |
-          node scripts/container-check-anonymous.ts \
-            --image "${DH_IMAGE}" \
-            --version "${VERSION}" \
-            --index-digest "${INDEX_DIGEST}"
+          set -euo pipefail
+          for image in "${DH_IMAGE}" "${GHCR_IMAGE}"; do
+            node scripts/container-check-anonymous.ts \
+              --image "${image}" \
+              --version "${VERSION}" \
+              --index-digest "${INDEX_DIGEST}"
+          done
 
       # Authenticated, because that is the functional path today and it needs no
       # environment secret: `packages: read` on this run's own token is enough to

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1251,8 +1251,8 @@ jobs:
       # Both registries, because both are documented in the README and a private
       # one fails every `docker pull` a user copies from it. GHCR packages are
       # private by default and do not inherit the repository's visibility; this
-      # one was made public by hand after 0.5.0 created it, and this step is what
-      # keeps it that way — flipping it back private now fails the release
+      # one was made public by hand once the first release had created it, and
+      # this step keeps it that way — flipping it back private now fails a release
       # instead of quietly breaking half the install instructions.
       - name: Both registries serve the release anonymously
         env:


### PR DESCRIPTION
GHCR was made public by hand after 0.5.0 created the package. Both registries are now read with no credentials, not just Docker Hub — the point being that a stranger copying either `docker pull` line from the README gets the release, which an authenticated check cannot prove. It also pins the visibility: flipping the package private again now fails a release rather than quietly breaking half the install instructions.

Verified against the live 0.5.0 images, logged out of both: both serve `sha256:3c5fe464…` anonymously.

🤖 Generated with [Claude Code](https://claude.com/claude-code)