### PR TITLE
fix(install): stop reporting Homebrew for a global npm install

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -86,3 +86,7 @@ docs/.vitepress/cache/
 docs/.vitepress/dist/
 docs/.vitepress/.temp/
 
+
+# Written by the Homebrew/Scoop/Chocolatey installers at the package root;
+# a local copy would make a checkout report the wrong install channel.
+.install-channel

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ Unreleased changes appear first and represent commits that have not yet been inc
 
 > Changes merged since the last versioned release that have not yet shipped in a tagged version.
 
+### Fixed
+- Fixed the upgrade command shown to anyone who installed LoopTroop with `npm install -g` on a machine whose Node came from Homebrew. Homebrew's Node puts global packages under the Homebrew prefix, which LoopTroop read as a Homebrew installation, so it advised `brew upgrade looptroop` — a command that fails, because no such formula was ever installed. Detection now looks for the Cellar entry Homebrew actually creates.
+- Made that fix reach the people it is for. The install channel is detected once and then remembered, and reinstalling puts the files back where they already were, so the remembered wrong answer would have outlived any correction to detection. A remembered answer that contradicts the location it was recorded for is now treated as stale and worked out again.
+- Stopped a configuration file naming a channel like `constructor` from being accepted as a real one.
+
+### Added
+- An installer may now state the channel outright by leaving a `.install-channel` file at the package root, instead of LoopTroop having to infer it from the install path. The three managed package channels all unpack the same files, so the path is often the only difference between them and sometimes not even that.
+
 ## 0.5.0 (2026-08-12)
 
 

--- a/server/lib/installChannel.ts
+++ b/server/lib/installChannel.ts
@@ -1,5 +1,5 @@
 import { dirname, resolve, sep } from 'node:path'
-import { existsSync } from 'node:fs'
+import { existsSync, readFileSync } from 'node:fs'
 import { fileURLToPath } from 'node:url'
 import { readSettingsFile, writeSettingsFile } from './appSettings'
 
@@ -22,29 +22,103 @@ const UPGRADE_COMMANDS: Record<InstallChannel, string> = {
 }
 
 /**
- * Infers how this copy was installed from where it lives on disk.
+ * File an installer may drop at the package root to state the channel outright.
  *
- * Telling the user the wrong upgrade command is worse than telling them none,
- * so anything ambiguous resolves to `unknown` rather than guessing npm.
+ * Homebrew, Scoop and Chocolatey all extract the same bundle, so nothing about
+ * the files themselves distinguishes them; only the manager that unpacked them
+ * knows, and this is where it says so. Deliberately at the package root rather
+ * than beside this module, because detection runs from `dist/server/lib` and an
+ * installer has no business knowing that.
  */
-export function detectInstallChannel(moduleDir = dirname(fileURLToPath(import.meta.url))): InstallChannel {
+export const INSTALL_CHANNEL_MARKER = '.install-channel'
+
+/** Depth is bounded so a detached or unusual layout cannot walk to `/` slowly. */
+const PACKAGE_ROOT_SEARCH_DEPTH = 12
+
+/**
+ * The directory holding this package's `package.json`, walking up from `dir`.
+ *
+ * Every install layout puts the manifest at the root of whatever was unpacked —
+ * a Cellar keg's `libexec`, a Scoop app directory, `node_modules/looptroop`, a
+ * checkout — so this is the one anchor that is the same shape everywhere.
+ */
+function findPackageRoot(dir: string): string | null {
+  let current = resolve(dir)
+
+  for (let depth = 0; depth < PACKAGE_ROOT_SEARCH_DEPTH; depth += 1) {
+    if (existsSync(resolve(current, 'package.json'))) return current
+
+    const parent = dirname(current)
+    if (parent === current) return null
+    current = parent
+  }
+
+  return null
+}
+
+function readChannelMarker(packageRoot: string | null): InstallChannel | null {
+  if (packageRoot === null) return null
+
+  let raw: string
+  try {
+    raw = readFileSync(resolve(packageRoot, INSTALL_CHANNEL_MARKER), 'utf8')
+  } catch {
+    return null
+  }
+
+  const value = raw.trim().toLowerCase()
+  // `unknown` is refused rather than honoured: it is what a truncated or garbage
+  // file also looks like, and honouring it would suppress better evidence.
+  return value !== 'unknown' && isInstallChannel(value) ? value : null
+}
+
+/**
+ * Evidence written by whoever installed this copy, which therefore cannot be
+ * stale in the way a path or a remembered answer can.
+ */
+function detectFromMarkers(moduleDir: string): InstallChannel | null {
   // Containers set this at build time; nothing else does.
   if (process.env.LOOPTROOP_CONTAINER === '1') return 'container'
 
+  return readChannelMarker(findPackageRoot(moduleDir))
+}
+
+/**
+ * Evidence inferred from where the files landed, for installs that left no
+ * marker — every npm install, and anything predating the marker.
+ */
+function detectFromShape(moduleDir: string): InstallChannel {
   const normalized = moduleDir.split(sep).join('/')
 
-  if (/\/Cellar\/looptroop\/|\/homebrew\//i.test(normalized)) return 'homebrew'
+  // Only the Cellar, never a bare `/homebrew/`: on a Mac whose Node came from
+  // Homebrew, a plain `npm install -g` lands in
+  // `/opt/homebrew/lib/node_modules/looptroop`, which the loose pattern called
+  // `homebrew` and answered with `brew upgrade looptroop` — a command that fails
+  // because no such formula is installed. The Cellar path covers Linuxbrew too.
+  if (/\/Cellar\/looptroop\//i.test(normalized)) return 'homebrew'
   if (/\/scoop\/apps\/looptroop\//i.test(normalized)) return 'scoop'
   if (/\/ProgramData\/chocolatey\//i.test(normalized)) return 'chocolatey'
   if (/\/node_modules\/looptroop\//.test(normalized)) return 'npm'
 
   // A checkout has the sources a published package never ships.
-  const packageRoot = resolve(moduleDir, '../../..')
-  if (existsSync(resolve(packageRoot, 'server')) && existsSync(resolve(packageRoot, '.git'))) {
+  const packageRoot = findPackageRoot(moduleDir)
+  if (packageRoot !== null && existsSync(resolve(packageRoot, 'server')) && existsSync(resolve(packageRoot, '.git'))) {
     return 'source'
   }
 
   return 'unknown'
+}
+
+/**
+ * Infers how this copy was installed.
+ *
+ * Precedence is `LOOPTROOP_CONTAINER=1` → marker file → path shape → `unknown`,
+ * strongest evidence first. Telling the user the wrong upgrade command is worse
+ * than telling them none, so anything ambiguous resolves to `unknown` rather
+ * than guessing npm.
+ */
+export function detectInstallChannel(moduleDir = dirname(fileURLToPath(import.meta.url))): InstallChannel {
+  return detectFromMarkers(moduleDir) ?? detectFromShape(moduleDir)
 }
 
 export function getInstallInfo(moduleDir?: string): InstallInfo {
@@ -65,7 +139,10 @@ export interface RecordedInstall {
 export const INSTALL_SETTINGS_KEY = 'install'
 
 function isInstallChannel(value: unknown): value is InstallChannel {
-  return typeof value === 'string' && value in UPGRADE_COMMANDS
+  // `hasOwn` rather than `in`: `in` walks the prototype chain, so `"constructor"`
+  // in a config file or a marker would pass and hand back Object's constructor
+  // where an upgrade command belongs.
+  return typeof value === 'string' && Object.hasOwn(UPGRADE_COMMANDS, value)
 }
 
 /** Reads the recorded channel, treating anything malformed as unrecorded. */
@@ -86,53 +163,79 @@ export interface ResolveInstallOptions {
   moduleDir?: string
 }
 
+function info(channel: InstallChannel): InstallInfo {
+  return { channel, upgradeCommand: UPGRADE_COMMANDS[channel] }
+}
+
+function record(channel: InstallChannel, moduleDir: string, configDir?: string): void {
+  try {
+    writeSettingsFile({ [INSTALL_SETTINGS_KEY]: { channel, path: moduleDir } }, configDir)
+  } catch {
+    // A read-only install or an unwritable config dir costs one re-detection
+    // per command and nothing else, so it must not fail the command itself.
+  }
+}
+
 /**
- * The install channel for this copy, detected once and then remembered.
+ * The install channel for this copy: strongest available evidence, remembered.
  *
- * Detection reads the filesystem and infers from a path, which is both wasteful
- * to repeat on every command and fragile — a package manager that relocates its
- * files changes the answer. Recording it means the guess is made when the
- * evidence is freshest, stays stable afterwards, and can be corrected by hand.
+ * Precedence is marker → record → path shape. A marker outranks the record
+ * because it was written by the thing that did the installing, and the record
+ * can be older than the install it describes; the record outranks a path shape
+ * because a shape is a guess and the record may be a human correcting one.
  *
- * One exception to "stays stable": inside the container image the build-time
- * marker overrides a record that says anything else. See below for why.
+ * The record is nonetheless checked against the path it was written for, and
+ * dropped when the two contradict each other. Without that, one wrong answer is
+ * permanent: a 0.5.0 user on a Homebrew-installed Node had `homebrew` written
+ * for a path under `node_modules`, and because reinstalling puts the files back
+ * at that same path, no later version's detection would ever run again. The
+ * check is the same one the container marker already justified, applied to
+ * ordinary channels: evidence that disagrees with itself is stale, not binding.
  */
 export function resolveInstallInfo(options: ResolveInstallOptions = {}): InstallInfo {
   const moduleDir = options.moduleDir ?? dirname(fileURLToPath(import.meta.url))
-  // Set at build time by the image and by nothing else, which makes it the one
-  // piece of evidence here that cannot be stale. The record can be: a config
-  // volume first filled by a global npm install and then mounted into a
-  // container carries `channel: npm`, and the pin below would keep answering
-  // `npm install -g looptroop@latest` inside a container — a command that
-  // upgrades a tree the next `docker run` throws away. It outranks a
-  // hand-written pin for the same reason: whatever the user meant to correct,
-  // they were not correcting the fact that this is a container.
-  const marked = process.env.LOOPTROOP_CONTAINER === '1'
   const recorded = readRecordedInstall(options.configDir)
+  const marker = detectFromMarkers(moduleDir)
 
-  // A recorded path that no longer matches means this copy moved, so the old
-  // answer describes an installation that is no longer the one running.
-  if (recorded && (recorded.path === undefined || recorded.path === moduleDir)) {
-    // Returned without re-recording when it already agrees with the marker, so
-    // a container does not write to its config volume on every command.
-    if (!marked || recorded.channel === 'container') {
-      return { channel: recorded.channel, upgradeCommand: UPGRADE_COMMANDS[recorded.channel] }
+  if (marker !== null) {
+    // A config volume first filled by a global npm install and then mounted into
+    // a container carries `channel: npm`, and answering from it would tell the
+    // user to `npm install -g` a tree the next `docker run` throws away. The
+    // same holds for a marker file: whatever the user meant to correct with a
+    // hand-written pin, they were not correcting who installed these files.
+    const agrees = recorded?.channel === marker
+    // Re-recording only when something would change, so a container does not
+    // write to its config volume on every command.
+    if (!agrees || (recorded.path !== undefined && recorded.path !== moduleDir)) {
+      record(marker, moduleDir, options.configDir)
     }
+    return info(marker)
   }
 
-  const channel = detectInstallChannel(moduleDir)
+  if (recorded) {
+    // No path means a human wrote this to correct a bad guess: it holds wherever
+    // the files live, and is never overwritten.
+    if (recorded.path === undefined) return info(recorded.channel)
+
+    if (recorded.path === moduleDir) {
+      const shape = detectFromShape(moduleDir)
+      // `unknown` is not a contradiction, just silence — a custom install root
+      // looks like this, and the record is the only thing that knows better.
+      if (shape === 'unknown' || shape === recorded.channel) return info(recorded.channel)
+
+      record(shape, moduleDir, options.configDir)
+      return info(shape)
+    }
+    // A recorded path that no longer matches means this copy moved, so the old
+    // answer describes an installation that is no longer the one running.
+  }
+
+  const channel = detectFromShape(moduleDir)
   // `unknown` is not worth recording: it is precisely the answer a later run —
   // one with LOOPTROOP_CONTAINER set, say — deserves another attempt at.
-  if (channel !== 'unknown') {
-    try {
-      writeSettingsFile({ [INSTALL_SETTINGS_KEY]: { channel, path: moduleDir } }, options.configDir)
-    } catch {
-      // A read-only install or an unwritable config dir costs one re-detection
-      // per command and nothing else, so it must not fail the command itself.
-    }
-  }
+  if (channel !== 'unknown') record(channel, moduleDir, options.configDir)
 
-  return { channel, upgradeCommand: UPGRADE_COMMANDS[channel] }
+  return info(channel)
 }
 
 /** Semver comparison limited to the numeric core; prereleases sort below release. */

--- a/server/lib/installChannel.ts
+++ b/server/lib/installChannel.ts
@@ -186,9 +186,9 @@ function record(channel: InstallChannel, moduleDir: string, configDir?: string):
  *
  * The record is nonetheless checked against the path it was written for, and
  * dropped when the two contradict each other. Without that, one wrong answer is
- * permanent: a 0.5.0 user on a Homebrew-installed Node had `homebrew` written
- * for a path under `node_modules`, and because reinstalling puts the files back
- * at that same path, no later version's detection would ever run again. The
+ * permanent: an earlier release wrote `homebrew` for paths under `node_modules`
+ * on any Mac whose Node came from Homebrew, and because reinstalling puts the
+ * files back at that same path, no later detection would ever run again. The
  * check is the same one the container marker already justified, applied to
  * ordinary channels: evidence that disagrees with itself is stale, not binding.
  */

--- a/tests/updateCheck.test.ts
+++ b/tests/updateCheck.test.ts
@@ -1,10 +1,11 @@
 import { describe, it, expect, afterEach, beforeEach } from 'vitest'
-import { mkdtempSync, rmSync, writeFileSync, readFileSync } from 'node:fs'
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync, readFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import {
   detectInstallChannel,
   getInstallInfo,
+  INSTALL_CHANNEL_MARKER,
   isNewerVersion,
   readRecordedInstall,
   resolveInstallInfo,
@@ -18,19 +19,45 @@ import { checkForUpdate, CHECK_INTERVAL_MS, formatUpdateNotice } from '../server
  */
 describe('install channel detection', () => {
   const previousContainer = process.env.LOOPTROOP_CONTAINER
+  const tempDirs: string[] = []
 
   afterEach(() => {
     if (previousContainer === undefined) delete process.env.LOOPTROOP_CONTAINER
     else process.env.LOOPTROOP_CONTAINER = previousContainer
+    for (const dir of tempDirs.splice(0)) rmSync(dir, { recursive: true, force: true })
   })
+
+  /** A package root with a real `package.json`, which is what detection anchors on. */
+  function makeInstallTree(marker?: string): string {
+    const root = mkdtempSync(join(tmpdir(), 'looptroop-tree-'))
+    tempDirs.push(root)
+    writeFileSync(join(root, 'package.json'), JSON.stringify({ name: 'looptroop' }))
+    if (marker !== undefined) writeFileSync(join(root, INSTALL_CHANNEL_MARKER), marker)
+    mkdirSync(join(root, 'dist', 'server', 'lib'), { recursive: true })
+    return root
+  }
 
   it.each([
     ['/usr/local/lib/node_modules/looptroop/dist/server/cli', 'npm'],
-    ['/opt/homebrew/Cellar/looptroop/0.5.0/libexec/dist/server/cli', 'homebrew'],
+    ['/opt/homebrew/Cellar/looptroop/9.9.9/libexec/dist/server/cli', 'homebrew'],
+    ['/home/linuxbrew/.linuxbrew/Cellar/looptroop/9.9.9/libexec/dist/server/cli', 'homebrew'],
     ['/home/u/scoop/apps/looptroop/current/dist/server/cli', 'scoop'],
     ['/c/ProgramData/chocolatey/lib/looptroop/dist/server/cli', 'chocolatey'],
   ])('detects %s as %s', (moduleDir, expected) => {
     expect(detectInstallChannel(moduleDir)).toBe(expected)
+  })
+
+  /**
+   * The bug this narrowing fixes: Homebrew's own Node puts global npm packages
+   * under the brew prefix, so `/homebrew/` matched an install brew knows nothing
+   * about, and the user was told to run `brew upgrade looptroop`.
+   */
+  it.each([
+    '/opt/homebrew/lib/node_modules/looptroop/dist/server/lib',
+    '/usr/local/lib/node_modules/looptroop/dist/server/lib',
+    '/home/linuxbrew/.linuxbrew/lib/node_modules/looptroop/dist/server/lib',
+  ])('calls a global npm install under a brew prefix npm: %s', (moduleDir) => {
+    expect(detectInstallChannel(moduleDir)).toBe('npm')
   })
 
   it('detects a container from the build-time marker', () => {
@@ -42,10 +69,47 @@ describe('install channel detection', () => {
     expect(detectInstallChannel('/some/unexpected/place')).toBe('unknown')
   })
 
+  it('reads the marker an installer left at the package root', () => {
+    // A Scoop root the path pattern cannot recognise, which is the whole reason
+    // the marker exists: only the installer knows who unpacked these files.
+    const root = makeInstallTree('scoop\n')
+    expect(detectInstallChannel(join(root, 'dist', 'server', 'lib'))).toBe('scoop')
+  })
+
+  it.each(['homebrew', 'scoop', 'chocolatey'])('honours a %s marker', (channel) => {
+    const root = makeInstallTree(channel)
+    expect(detectInstallChannel(join(root, 'dist', 'server', 'lib'))).toBe(channel)
+  })
+
+  it('lets the container marker outrank a marker file', () => {
+    process.env.LOOPTROOP_CONTAINER = '1'
+    const root = makeInstallTree('homebrew')
+    expect(detectInstallChannel(join(root, 'dist', 'server', 'lib'))).toBe('container')
+  })
+
+  it('lets a marker file outrank the path shape', () => {
+    const root = mkdtempSync(join(tmpdir(), 'looptroop-shape-'))
+    tempDirs.push(root)
+    // Deliberately a path the shape rules read as chocolatey.
+    const packageRoot = join(root, 'ProgramData', 'chocolatey', 'lib', 'looptroop')
+    mkdirSync(join(packageRoot, 'dist', 'server', 'lib'), { recursive: true })
+    writeFileSync(join(packageRoot, 'package.json'), '{}')
+    writeFileSync(join(packageRoot, INSTALL_CHANNEL_MARKER), 'scoop')
+
+    expect(detectInstallChannel(join(packageRoot, 'dist', 'server', 'lib'))).toBe('scoop')
+  })
+
+  it.each(['', 'apt-get', 'unknown', 'x'.repeat(400)])('ignores the unusable marker %j', (contents) => {
+    const root = makeInstallTree(contents)
+    // Falls through to the shape rules, which have nothing to say about a temp
+    // directory — better than honouring a truncated or garbage file.
+    expect(detectInstallChannel(join(root, 'dist', 'server', 'lib'))).toBe('unknown')
+  })
+
   it('pairs every channel with a usable upgrade command', () => {
     expect(getInstallInfo('/usr/local/lib/node_modules/looptroop/dist/server/cli').upgradeCommand)
       .toBe('npm install -g looptroop@latest')
-    expect(getInstallInfo('/opt/homebrew/Cellar/looptroop/0.5.0/dist/server/cli').upgradeCommand)
+    expect(getInstallInfo('/opt/homebrew/Cellar/looptroop/9.9.9/libexec/dist/server/cli').upgradeCommand)
       .toBe('brew upgrade looptroop')
   })
 })
@@ -85,16 +149,70 @@ describe('recorded install channel', () => {
     expect(readRecordedInstall(configDir)).toEqual({ channel: 'npm', path: NPM_DIR })
   })
 
-  it('reuses the recorded answer instead of detecting again', () => {
+  it('reuses the recorded answer where detection has nothing to say', () => {
     const configDir = makeConfigDir()
+    const CUSTOM_DIR = '/opt/tools/looptroop-app/dist/server/lib'
     writeFileSync(
       join(configDir, 'config.json'),
-      JSON.stringify({ install: { channel: 'homebrew', path: NPM_DIR } }),
+      JSON.stringify({ install: { channel: 'scoop', path: CUSTOM_DIR } }),
     )
 
-    // The path says npm; the recorded channel is what must win, which is only
-    // observable because the two disagree.
-    expect(resolveInstallInfo({ configDir, moduleDir: NPM_DIR }).channel).toBe('homebrew')
+    // Detection reads this path as `unknown`, which is silence rather than
+    // disagreement: the record is the only thing that knows, so it stands.
+    expect(resolveInstallInfo({ configDir, moduleDir: CUSTOM_DIR }).channel).toBe('scoop')
+  })
+
+  /**
+   * 0.5.0 wrote `homebrew` for paths under `node_modules` on any Mac whose Node
+   * came from Homebrew. Reinstalling puts the files back at the same path, so
+   * without this the record pins that wrong answer forever and no later fix to
+   * detection can ever reach those users.
+   */
+  it('heals a record that contradicts the path it was written for', () => {
+    const configDir = makeConfigDir()
+    const BREW_NODE_NPM_DIR = '/opt/homebrew/lib/node_modules/looptroop/dist/server/lib'
+    writeFileSync(
+      join(configDir, 'config.json'),
+      JSON.stringify({ install: { channel: 'homebrew', path: BREW_NODE_NPM_DIR } }),
+    )
+
+    const info = resolveInstallInfo({ configDir, moduleDir: BREW_NODE_NPM_DIR })
+
+    expect(info.channel).toBe('npm')
+    expect(info.upgradeCommand).toBe('npm install -g looptroop@latest')
+    expect(readRecordedInstall(configDir)).toEqual({ channel: 'npm', path: BREW_NODE_NPM_DIR })
+  })
+
+  it('lets a marker file outrank a record written before it existed', () => {
+    const configDir = makeConfigDir()
+    const root = mkdtempSync(join(tmpdir(), 'looptroop-marked-'))
+    tempDirs.push(root)
+    writeFileSync(join(root, 'package.json'), '{}')
+    writeFileSync(join(root, INSTALL_CHANNEL_MARKER), 'chocolatey')
+    const moduleDir = join(root, 'dist', 'server', 'lib')
+    writeFileSync(join(configDir, 'config.json'), JSON.stringify({ install: { channel: 'npm', path: moduleDir } }))
+
+    expect(resolveInstallInfo({ configDir, moduleDir }).channel).toBe('chocolatey')
+    expect(readRecordedInstall(configDir)).toEqual({ channel: 'chocolatey', path: moduleDir })
+  })
+
+  it('does not rewrite a record the path agrees with', () => {
+    const configDir = makeConfigDir()
+    // Compact JSON: a rewrite pretty-prints, so the bytes are what proves the
+    // common case touches no disk.
+    const original = JSON.stringify({ install: { channel: 'npm', path: NPM_DIR } })
+    writeFileSync(join(configDir, 'config.json'), original)
+
+    expect(resolveInstallInfo({ configDir, moduleDir: NPM_DIR }).channel).toBe('npm')
+    expect(readFileSync(join(configDir, 'config.json'), 'utf8')).toBe(original)
+  })
+
+  it('ignores a channel inherited from Object.prototype', () => {
+    const configDir = makeConfigDir()
+    writeFileSync(join(configDir, 'config.json'), JSON.stringify({ install: { channel: 'constructor' } }))
+
+    expect(readRecordedInstall(configDir)).toBeNull()
+    expect(typeof resolveInstallInfo({ configDir, moduleDir: NPM_DIR }).upgradeCommand).toBe('string')
   })
 
   it('detects again once this copy has moved', () => {


### PR DESCRIPTION
## What

Three fixes to install-channel detection, ahead of the Homebrew/Scoop/Chocolatey work that depends on it.

**The bug.** `detectInstallChannel` matched a bare `/homebrew/` anywhere in the module path. Homebrew's own Node keeps global npm packages under the Homebrew prefix, so `npm install -g looptroop` on such a Mac lands in `/opt/homebrew/lib/node_modules/looptroop` and was read as a Homebrew install. Those users are told to run `brew upgrade looptroop`, which fails — no such formula was ever installed. The match is now the Cellar entry Homebrew actually creates, which covers Linuxbrew too.

**Why the fix alone would not have reached anyone.** `resolveInstallInfo` records the first confident answer and returns it whenever the recorded path still matches, without detecting again. Reinstalling puts the files back at that same path, so the wrong answer 0.5.0 wrote would outlive every future correction. A record whose path contradicts the channel it claims is now stale: detect again, rewrite. Silence is not contradiction — a path detection has no opinion about still yields to the record — and a hand-written pin (the form with no `path`) is still never overwritten.

**A marker file.** `.install-channel` at the package root lets an installer state the channel outright. Homebrew, Scoop and Chocolatey will all unpack the same bundle, so the path is often the only thing distinguishing them and sometimes not even that. Read from the package root by walking up to `package.json`, because an installer has no business knowing detection runs from `dist/server/lib`. Precedence is now explicit and tested: `LOOPTROOP_CONTAINER=1` → marker file → path shape → `unknown`.

Also swaps `in` for `Object.hasOwn` in the channel validator: `in` walks the prototype chain, so `"channel": "constructor"` in config.json validated and returned `Object`'s constructor where an upgrade command belonged.

## Side effects

Detection now runs on every command rather than only when the record is missing or the path moved — a bounded directory walk plus at most two `existsSync` calls, and it is what makes a stale record self-correcting. The no-change path still writes nothing to disk, which a test asserts on the raw bytes.

## Tests

`tests/updateCheck.test.ts`: the five real install layouts plus Linuxbrew; three global-npm-under-a-brew-prefix paths; marker precedence in both directions; unusable marker contents; the poisoned-record case; and the prototype-chain channel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)