### PR TITLE
fix(release): pin repair renderers, verify the Chocolatey bundle, correct the README

### DIFF
--- a/.github/workflows/channel-republish.yml
+++ b/.github/workflows/channel-republish.yml
@@ -11,12 +11,24 @@
 # so once npm and the tag are done a re-run of `release.yml` resolves to
 # `complete` and skips these jobs entirely.
 #
-# Nothing is rebuilt from a checkout. Everything a descriptor contains — the
-# version, the bundle URL and its sha256 — is read from `release-manifest.json`
-# attached to the published GitHub Release. Release assets outlive workflow
-# artefacts, which is what lets this run months after the release it repairs,
-# and reading them rather than rebuilding means a repair cannot publish a
-# descriptor pointing at bytes the release never had.
+# Everything a descriptor contains — the version, the bundle URL and its sha256
+# — is read from `release-manifest.json` attached to the published GitHub
+# Release, never from a checkout. Release assets outlive workflow artefacts,
+# which is what lets this run months after the release it repairs, and reading
+# them rather than rebuilding means a repair cannot publish a descriptor
+# pointing at bytes the release never had.
+#
+# The publish jobs then check out the commit that release was built from, so the
+# templates rendering those values are that release's own. Together the two
+# pin both halves: the manifest pins what a descriptor says, the commit pins the
+# code that says it. Without the second, editing a formula template silently
+# rewrites every older release anyone later repairs.
+#
+# The cost is that this file — always the default branch's, because that is
+# where `workflow_dispatch` reads it from — invokes scripts from an older
+# checkout. Adding a flag is safe, since the argument parsers ignore ones they
+# do not know. Removing or renaming a flag that an older script requires is not,
+# and would surface as a repair failing on an old version long after the change.
 #
 # What it will not do by default is overwrite. A channel already carrying this
 # version with these exact bytes is left alone; one carrying a newer version is
@@ -69,6 +81,7 @@ jobs:
       url: ${{ steps.inputs.outputs.url }}
       sha256: ${{ steps.inputs.outputs.sha256 }}
       force: ${{ steps.force.outputs.force }}
+      templates: ${{ steps.templates.outputs.ref }}
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
@@ -150,6 +163,39 @@ jobs:
             exit 1
           fi
 
+      # Which commit's templates render this release's descriptors.
+      #
+      # The version, URL and sha256 above pin what a descriptor *says*; they do
+      # not pin the code that writes it. A repair runs from the default branch,
+      # so without this a formula rebuilt a year later carries whatever
+      # `package-manifests.ts` says then — a changed dependency, a changed
+      # caveat, a changed install block — and publishes it as though that were
+      # what the release shipped. Nobody reviewing the template change would
+      # know they had also just changed four old releases.
+      #
+      # So the release's own commit wins. Re-rendering an old release with new
+      # templates is a change to what that release publishes, and it belongs in
+      # a reviewed code change rather than behind a dispatch checkbox.
+      #
+      # Falling back to the default branch when the manifest records no commit,
+      # which is every manifest written before the field existed. Those releases
+      # carry no bundle either, so `channel-inputs.ts` has already refused them
+      # and this is unreachable — it is here so that a future gap degrades to
+      # today's behaviour rather than to an empty ref.
+      - name: Resolve which templates to render with
+        id: templates
+        env:
+          COMMIT: ${{ steps.inputs.outputs.commit }}
+        run: |
+          set -euo pipefail
+          if [ -n "${COMMIT}" ]; then
+            echo "ref=${COMMIT}" >> "$GITHUB_OUTPUT"
+            echo "Rendering with the templates from ${COMMIT}, the commit this release was built from."
+          else
+            echo "ref=${GITHUB_SHA}" >> "$GITHUB_OUTPUT"
+            echo "::warning::This release's manifest records no commit; rendering with the default branch."
+          fi
+
   # ---------------------------------------------------------------------------
   # Homebrew and Scoop: a file in a git repository, written through the contents
   # API so a concurrent push loses rather than this one.
@@ -166,6 +212,8 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           persist-credentials: false
+          # The release's own templates, not the default branch's. See `prepare`.
+          ref: ${{ needs.prepare.outputs.templates }}
 
       - name: Set up Node
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
@@ -221,6 +269,8 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           persist-credentials: false
+          # The release's own templates, not the default branch's. See `prepare`.
+          ref: ${{ needs.prepare.outputs.templates }}
 
       - name: Set up Node
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
@@ -265,6 +315,8 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           persist-credentials: false
+          # The release's own templates, not the default branch's. See `prepare`.
+          ref: ${{ needs.prepare.outputs.templates }}
 
       - name: Set up Node
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
@@ -289,14 +341,23 @@ jobs:
             echo "looptroop ${VERSION} is not on the feed (either never submitted, or still in moderation)."
           fi
 
+      # By exact name, not `*-bundle.tar.gz`. The manifest names the asset this
+      # release published, so asking for anything else means accepting whatever
+      # a glob happens to match on a release that also carries an older or
+      # differently-named archive.
       - name: Download the bundle this release published
         if: steps.feed.outputs.published == 'false'
         shell: bash
         env:
           GH_TOKEN: ${{ github.token }}
           VERSION: ${{ needs.prepare.outputs.version }}
-        run: gh release download "v${VERSION}" --repo "${GITHUB_REPOSITORY}" --pattern '*-bundle.tar.gz' --clobber
+          BUNDLE: ${{ needs.prepare.outputs.bundle }}
+        run: gh release download "v${VERSION}" --repo "${GITHUB_REPOSITORY}" --pattern "${BUNDLE}" --clobber
 
+      # `--expect-sha256`, because these bytes were downloaded rather than built
+      # here and go straight inside the package. Homebrew gets this check from
+      # `brew audit --online`; Chocolatey has no equivalent, so it happens here
+      # or not at all.
       - name: Pack and prove it locally
         if: steps.feed.outputs.published == 'false'
         shell: bash
@@ -306,6 +367,7 @@ jobs:
             --bundle "${{ needs.prepare.outputs.bundle }}" \
             --url "${{ needs.prepare.outputs.url }}" \
             --version "${{ needs.prepare.outputs.version }}" \
+            --expect-sha256 "${{ needs.prepare.outputs.sha256 }}" \
             --out dist-choco
           node scripts/smoke-choco.ts \
             --nupkg "dist-choco/looptroop.${{ needs.prepare.outputs.version }}.nupkg" \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1525,6 +1525,11 @@ jobs:
         shell: bash
         run: node scripts/channel-inputs.ts --manifest release-manifest.json --repo "${GITHUB_REPOSITORY}"
 
+      # `--expect-sha256` against the manifest, even though the bundle and the
+      # manifest came out of the same build job. They travelled here separately
+      # as artefact bytes, and this package embeds the bundle rather than
+      # fetching it, so this is the last moment either can be compared with the
+      # other before whatever is here becomes what Chocolatey users get.
       - name: Pack the package
         shell: bash
         run: >
@@ -1532,6 +1537,7 @@ jobs:
           --bundle "${{ steps.inputs.outputs.bundle }}"
           --url "${{ steps.inputs.outputs.url }}"
           --version "${{ steps.inputs.outputs.version }}"
+          --expect-sha256 "${{ steps.inputs.outputs.sha256 }}"
           --out dist-choco
 
       # The exact nupkg that is about to be pushed, installed and run first.

--- a/README.md
+++ b/README.md
@@ -210,8 +210,14 @@ The three package managers install a bundle built once per release, with every
 dependency resolved at build time — so everyone on those channels runs the exact
 versions the release was tested against. Installing through npm resolves the
 version ranges afresh on your machine, which is how npm is supposed to work and
-is worth knowing when comparing two installations. Node itself is never
-installed for you on any channel.
+is worth knowing when comparing two installations.
+
+Node is the one thing those three will install for you: LoopTroop is declared as
+depending on it, so Homebrew pulls in `node@24` and Scoop and Chocolatey pull in
+`nodejs-lts` if your machine has no suitable Node. That is the normal contract
+of a package manager, and it is the difference between them and the one-line
+installer above, which checks for Node, tells you what to do about it, and
+installs nothing itself.
 
 ### Or install with a script
 

--- a/scripts/build-choco.ts
+++ b/scripts/build-choco.ts
@@ -64,6 +64,29 @@ if (basename(bundlePath) !== bundleFileName(version)) {
   )
 }
 
+// The digest above is computed from whatever file was handed over, so on its own
+// it only proves the package is self-consistent — a corrupt or substituted
+// bundle would be hashed just as happily and shipped with a verification file
+// that agrees with it perfectly.
+//
+// This is the check Homebrew gets for free from `brew audit --online`, which
+// fetches the URL and compares. Chocolatey carries the bundle *inside* the
+// package rather than fetching it, so nothing downstream ever compares these
+// bytes against the release again: whatever goes in here is what users get, and
+// this is the last point at which it can be checked at all.
+//
+// Optional, because the release workflow builds the bundle and packs it in one
+// run with no download in between. A repair downloads it, and passes this.
+const expected = process.argv.includes('--expect-sha256') ? flag('expect-sha256') : null
+if (expected !== null && expected !== sha256) {
+  fail(
+    'The bundle does not match the checksum the release recorded for it.',
+    `expected ${expected}`,
+    `actual   ${sha256}`,
+    'Packing this would embed bytes that release never published.',
+  )
+}
+
 const inputs = { version, url, sha256 }
 const stagingDir = join(outDir, 'package')
 const toolsDir = join(stagingDir, 'tools')

--- a/scripts/channel-inputs.ts
+++ b/scripts/channel-inputs.ts
@@ -10,6 +10,10 @@
  * reproduces the same descriptor from the same source of truth — which is what
  * makes attaching the rendered files to the release unnecessary.
  *
+ * The commit comes out too, because those three values pin the *inputs* to the
+ * rendering and not the renderer. Checking it out is what stops a template
+ * changed since the release from quietly altering what that release publishes.
+ *
  * The URL is constructed rather than looked up. A published release asset lives
  * at a predictable address, and constructing it means this works before the
  * release exists as well as after — the audit step needs it either way.
@@ -57,6 +61,12 @@ const output = {
   bundle,
   sha256: assets[bundle]!.sha256,
   url: `https://github.com/${repo}/releases/download/v${manifest.version}/${bundle}`,
+  // The commit this release was built from, so a repair can render descriptors
+  // with that release's templates rather than whatever the default branch says
+  // today. Empty when the manifest predates the field or the release was built
+  // outside a checkout; the caller decides what to do about that, because
+  // "reproduce this exactly" and "do something reasonable" are different jobs.
+  commit: manifest.commit ?? '',
 }
 
 const lines = Object.entries(output).map(([key, value]) => `${key}=${value}`)


### PR DESCRIPTION
Three more review findings, all confirmed against the code.

## A Chocolatey repair never checked the bundle it downloaded

The repair job pulled the bundle with a `*-bundle.tar.gz` glob and handed it
straight to `build-choco.ts`, which hashes whatever it is given and writes that
hash into `VERIFICATION.txt`. The package was therefore **self-consistent by
construction and compared against the release not at all** — a corrupt or
substituted archive would have been packed just as happily, with a verification
file agreeing with it perfectly.

Homebrew gets this check for free from `brew audit --online`, which fetches the
URL and compares. Chocolatey carries the bundle *inside* the package rather than
fetching it, so nothing downstream ever compares those bytes again — this was
the last point at which it could be checked at all.

- `build-choco.ts` takes an optional `--expect-sha256` and refuses to pack on
  disagreement.
- Passed from the manifest in the repair job **and** the release job. In the
  release job the bundle and manifest came from the same build, but travelled
  here as separate artefact bytes, which is still worth comparing.
- The repair downloads by the exact name the manifest records, not a glob.

Verified locally:

```
mismatch exit=1   ← fails before staging
match    exit=1   ← passes the check, reaches `choco pack` (absent on Linux)
omitted  exit=1   ← same; check is opt-in
```

## Repairs rendered old releases with today's templates

The manifest pins what a descriptor *says* — version, URL, sha256 — but not the
code that writes it, and a repair runs from the default branch. A formula
rebuilt a year from now would carry whatever `package-manifests.ts` says then,
published as though it were what the release shipped. Nobody reviewing the
template change would know they had also just changed four old releases.

`channel-inputs.ts` now reports the commit **the manifest already recorded**, and
the three publish jobs check it out. `prepare` deliberately stays on the default
branch — reading the release and deciding what to do is this workflow's job;
rendering is the release's.

```
prepare       -> {persist-credentials: false}
push-formula  -> {persist-credentials: false, ref: <release commit>}
push-manifest -> {persist-credentials: false, ref: <release commit>}
chocolatey    -> {persist-credentials: false, ref: <release commit>}
```

This is the **lower-complexity half of D9**. It does not attach the descriptors,
so it is not byte-for-byte recovery, but it removes the mechanism by which a
repair silently diverges — which was the actual risk. Re-rendering an old
release with new templates is a change to what that release published, so it now
requires a reviewed code change rather than a dispatch checkbox.

Residual coupling, documented at the top of the workflow: this file is always the
default branch's while the scripts it calls are the release's. Adding a flag is
safe (the parsers ignore unknown ones); removing or renaming one that an older
script requires is not.

## The README said Node is never installed on any channel

It is. All three declare it, and the goldens prove it:

| channel | declares |
|---|---|
| Homebrew | `depends_on "node@24"` |
| Scoop | `"nodejs-lts"` |
| Chocolatey | `<dependency id="nodejs-lts" version="24.15.0" />` |

The claim is true of the **one-line installer**, which checks for Node and
installs nothing itself. That distinction is now what the paragraph draws.

## Verification

`lint`, `typecheck`, `verify:version`, `verify:strip-types` pass; all three
workflows parse. Full suite: 3220 passed, 2 skipped.

Also verified by hand: `channel-inputs.ts` emits the commit, and degrades to
empty for a manifest recording none.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
