### PR TITLE
fix(release): stop the 0.5.1 bump tripping the version scanner

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,11 +189,11 @@ review gates.
 
 ### Or use a package manager
 
-> **Homebrew, Scoop and Chocolatey carry LoopTroop from 0.5.1 onwards.** Until
-> that release is published these three commands have nothing to find; npm and
-> Docker work today. The Chocolatey package additionally has to clear community
-> moderation before the feed serves it, which is not something a release can
-> wait on.
+> **Homebrew, Scoop and Chocolatey are not populated yet.** The next stable
+> release is the first to publish to them, so until it is out these three
+> commands have nothing to find; npm and Docker work today. The Chocolatey
+> package additionally has to clear community moderation before the feed serves
+> it, which is not something a release can wait on.
 
 | | Install | Upgrade |
 |---|---|---|

--- a/scripts/smoke-choco.ts
+++ b/scripts/smoke-choco.ts
@@ -3,7 +3,7 @@
  * Installs the Chocolatey package, drives it, and uninstalls it again.
  *
  *   node scripts/smoke-choco.ts --nupkg dist-choco/looptroop.9.9.9.nupkg
- *   node scripts/smoke-choco.ts --from-feed --version 0.5.1
+ *   node scripts/smoke-choco.ts --from-feed --version 9.9.9
  *
  * The two modes answer two different questions and both are needed.
  *


### PR DESCRIPTION
A dry run of the release PR for 0.5.1 failed at `verify:version`. Both offenders
were written earlier today while fixing review findings:

```
README.md:192             [current 0.5.1] > **Homebrew, Scoop and Chocolatey
                          carry LoopTroop from 0.5.1 onwards.** Until
scripts/smoke-choco.ts:6  [current 0.5.1] *   node scripts/smoke-choco.ts
                          --from-feed --version 0.5.1
```

- The README note is about a version that does not exist yet, so it now says
  "the next stable release" instead of naming one. Still reads as the temporary
  note it is, and stays true longer.
- The `smoke-choco.ts` usage example moves to `9.9.9`, the placeholder the line
  above it and the channel fixtures already use.

## Verification

Simulated the bump by setting `package.json` to 0.5.1 and rerunning the scanner:

```
Checked 889 tracked files against version 0.5.1 (and stale 0.5.0).

FAIL: version fields are out of sync.
  package-lock.json "version" is 0.5.0, expected 0.5.1.
```

No hardcoded references. The only complaint left is the lockfile, which
`release-bump.ts` resyncs as part of a real bump.

Worth noting the pattern: **any sentence about "the next release" that names it
becomes a release blocker the moment it is right.** This is the same trap the
previous PR allowlisted `tests/installer.test.ts` for, arriving one release
earlier and from new prose rather than fixtures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)