### PR TITLE
fix(installer): report the version actually installed, not whatever answers on PATH

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ Unreleased changes appear first and represent commits that have not yet been inc
 
 > Changes merged since the last versioned release that have not yet shipped in a tagged version.
 
+### Fixed
+- Stopped the one-line installer reporting the wrong version when another copy of LoopTroop comes first on your PATH. It finished by running `looptroop --version` and printing whatever answered, which is a different copy whenever an older one is earlier in the search order — including when npm's global directory is not on the PATH at all, in which case it cheerfully reported a successful install of a version it had not touched. It now names the version it actually installed, and says so plainly when the command your shell will run is a different one.
+
+### Changed
+- The README no longer says the package managers are unpopulated, and describes the one way Chocolatey genuinely differs: every version waits for community moderation, so it trails the other channels rather than arriving with them.
+
 ## 0.5.1 (2026-08-13)
 
 

--- a/README.md
+++ b/README.md
@@ -189,11 +189,9 @@ review gates.
 
 ### Or use a package manager
 
-> **Homebrew, Scoop and Chocolatey are not populated yet.** The next stable
-> release is the first to publish to them, so until it is out these three
-> commands have nothing to find; npm and Docker work today. The Chocolatey
-> package additionally has to clear community moderation before the feed serves
-> it, which is not something a release can wait on.
+> **Chocolatey lags the other channels.** Every version goes through community
+> moderation before the feed serves it, and no release waits on that — so a new
+> version reaches Homebrew, Scoop and npm first, and Chocolatey once it clears.
 
 | | Install | Upgrade |
 |---|---|---|

--- a/install.ps1
+++ b/install.ps1
@@ -309,6 +309,10 @@ function installGlobally(tarball) {
 async function main(argv) {
   const options = parseArgs(argv)
   const workDir = mkdtempSync(resolve(tmpdir(), 'looptroop-install-'))
+  // What we resolved and installed, so the closing message can be checked
+  // against it. Stays null for `--tarball`, where a local file is taken on
+  // trust and there is no release to name a version.
+  let intended = null
 
   try {
     if (options.tarball !== null) {
@@ -343,7 +347,8 @@ async function main(argv) {
       }
 
       const { manifest: manifestAsset, tarball: tarballAsset } = installableAssets(release)
-      say(`Installing LoopTroop ${versionOf(release)}`)
+      intended = versionOf(release)
+      say(`Installing LoopTroop ${intended}`)
 
       const manifestPath = resolve(workDir, MANIFEST_ASSET)
       await download(manifestAsset.browser_download_url, manifestPath)
@@ -371,13 +376,28 @@ async function main(argv) {
   // Advisory only. `doctor` exits non-zero until OpenCode is set up, which is
   // the normal state seconds after installing, so a failing check here would
   // report a broken install that is not broken.
+  //
+  // This runs the bare command, deliberately: the question it answers is what
+  // the user's shell will do when they type `looptroop`, not whether files
+  // landed on disk. But that means the answer can come from a different copy
+  // earlier in PATH, so it is checked against what was actually installed
+  // rather than reported as though it must be the same thing. Reporting it
+  // blindly claimed a successful install of whatever version happened to
+  // answer — including, when npm's global bin is not on PATH at all, an older
+  // copy that the install never touched.
   const probe = spawnSync('looptroop', ['--version'], { encoding: 'utf8', shell: process.platform === 'win32' })
+  const reported = probe.status === 0 ? String(probe.stdout).trim() : null
   say('')
-  if (probe.status === 0) {
-    say(`Installed: looptroop ${String(probe.stdout).trim()}`)
-  } else {
+  if (reported === null) {
     say('Installed, but `looptroop` is not on your PATH yet.')
     say('Open a new terminal, or add npm\'s global bin directory to PATH: npm prefix -g')
+  } else if (intended === null || reported === intended) {
+    say(`Installed: looptroop ${reported}`)
+  } else {
+    say(`Installed: looptroop ${intended}`)
+    say('')
+    say(`But \`looptroop\` on your PATH is ${reported}, so another copy comes first.`)
+    say(`Find it with: ${process.platform === 'win32' ? 'where looptroop' : 'command -v looptroop'}`)
   }
   say('')
   say('Next: run `looptroop doctor` to check your setup, then `looptroop setup`.')

--- a/install.sh
+++ b/install.sh
@@ -313,6 +313,10 @@ function installGlobally(tarball) {
 async function main(argv) {
   const options = parseArgs(argv)
   const workDir = mkdtempSync(resolve(tmpdir(), 'looptroop-install-'))
+  // What we resolved and installed, so the closing message can be checked
+  // against it. Stays null for `--tarball`, where a local file is taken on
+  // trust and there is no release to name a version.
+  let intended = null
 
   try {
     if (options.tarball !== null) {
@@ -347,7 +351,8 @@ async function main(argv) {
       }
 
       const { manifest: manifestAsset, tarball: tarballAsset } = installableAssets(release)
-      say(`Installing LoopTroop ${versionOf(release)}`)
+      intended = versionOf(release)
+      say(`Installing LoopTroop ${intended}`)
 
       const manifestPath = resolve(workDir, MANIFEST_ASSET)
       await download(manifestAsset.browser_download_url, manifestPath)
@@ -375,13 +380,28 @@ async function main(argv) {
   // Advisory only. `doctor` exits non-zero until OpenCode is set up, which is
   // the normal state seconds after installing, so a failing check here would
   // report a broken install that is not broken.
+  //
+  // This runs the bare command, deliberately: the question it answers is what
+  // the user's shell will do when they type `looptroop`, not whether files
+  // landed on disk. But that means the answer can come from a different copy
+  // earlier in PATH, so it is checked against what was actually installed
+  // rather than reported as though it must be the same thing. Reporting it
+  // blindly claimed a successful install of whatever version happened to
+  // answer — including, when npm's global bin is not on PATH at all, an older
+  // copy that the install never touched.
   const probe = spawnSync('looptroop', ['--version'], { encoding: 'utf8', shell: process.platform === 'win32' })
+  const reported = probe.status === 0 ? String(probe.stdout).trim() : null
   say('')
-  if (probe.status === 0) {
-    say(`Installed: looptroop ${String(probe.stdout).trim()}`)
-  } else {
+  if (reported === null) {
     say('Installed, but `looptroop` is not on your PATH yet.')
     say('Open a new terminal, or add npm\'s global bin directory to PATH: npm prefix -g')
+  } else if (intended === null || reported === intended) {
+    say(`Installed: looptroop ${reported}`)
+  } else {
+    say(`Installed: looptroop ${intended}`)
+    say('')
+    say(`But \`looptroop\` on your PATH is ${reported}, so another copy comes first.`)
+    say(`Find it with: ${process.platform === 'win32' ? 'where looptroop' : 'command -v looptroop'}`)
   }
   say('')
   say('Next: run `looptroop doctor` to check your setup, then `looptroop setup`.')

--- a/scripts/installer-core.mjs
+++ b/scripts/installer-core.mjs
@@ -272,6 +272,10 @@ function installGlobally(tarball) {
 async function main(argv) {
   const options = parseArgs(argv)
   const workDir = mkdtempSync(resolve(tmpdir(), 'looptroop-install-'))
+  // What we resolved and installed, so the closing message can be checked
+  // against it. Stays null for `--tarball`, where a local file is taken on
+  // trust and there is no release to name a version.
+  let intended = null
 
   try {
     if (options.tarball !== null) {
@@ -306,7 +310,8 @@ async function main(argv) {
       }
 
       const { manifest: manifestAsset, tarball: tarballAsset } = installableAssets(release)
-      say(`Installing LoopTroop ${versionOf(release)}`)
+      intended = versionOf(release)
+      say(`Installing LoopTroop ${intended}`)
 
       const manifestPath = resolve(workDir, MANIFEST_ASSET)
       await download(manifestAsset.browser_download_url, manifestPath)
@@ -334,13 +339,28 @@ async function main(argv) {
   // Advisory only. `doctor` exits non-zero until OpenCode is set up, which is
   // the normal state seconds after installing, so a failing check here would
   // report a broken install that is not broken.
+  //
+  // This runs the bare command, deliberately: the question it answers is what
+  // the user's shell will do when they type `looptroop`, not whether files
+  // landed on disk. But that means the answer can come from a different copy
+  // earlier in PATH, so it is checked against what was actually installed
+  // rather than reported as though it must be the same thing. Reporting it
+  // blindly claimed a successful install of whatever version happened to
+  // answer — including, when npm's global bin is not on PATH at all, an older
+  // copy that the install never touched.
   const probe = spawnSync('looptroop', ['--version'], { encoding: 'utf8', shell: process.platform === 'win32' })
+  const reported = probe.status === 0 ? String(probe.stdout).trim() : null
   say('')
-  if (probe.status === 0) {
-    say(`Installed: looptroop ${String(probe.stdout).trim()}`)
-  } else {
+  if (reported === null) {
     say('Installed, but `looptroop` is not on your PATH yet.')
     say('Open a new terminal, or add npm\'s global bin directory to PATH: npm prefix -g')
+  } else if (intended === null || reported === intended) {
+    say(`Installed: looptroop ${reported}`)
+  } else {
+    say(`Installed: looptroop ${intended}`)
+    say('')
+    say(`But \`looptroop\` on your PATH is ${reported}, so another copy comes first.`)
+    say(`Find it with: ${process.platform === 'win32' ? 'where looptroop' : 'command -v looptroop'}`)
   }
   say('')
   say('Next: run `looptroop doctor` to check your setup, then `looptroop setup`.')


### PR DESCRIPTION
Found by installing 0.5.1 through the **public one-liner**, on a machine that
already had 0.5.0 at `/usr/bin/looptroop`:

```
Verified sha256 0b03168cd5fd4a5aab9c74f671aba6ea8fffbb50dd20a49a794a5da39ab429d8
Installing with npm...
added 16 packages in 13s
Installed: looptroop 0.5.0        ← wrong
```

The install was correct — that sha256 is 0.5.1's tarball, and the installed
`package.json` said `0.5.1`. Only the message was wrong.

## Why

The closing probe runs the bare command and printed whatever came back. Running
the bare command is *right* — the useful question is what the user's shell does
when they type `looptroop`, not whether files reached disk. But its answer is not
necessarily the copy just installed, and it was reported as though it were.

**The cosmetic case is not the bad one.** When npm's global bin is not on `PATH`
at all — common — an older copy answers, and the installer reports a successful
install of a version it never touched. The existing "not on your PATH yet" branch
only fires when *nothing* answers.

## Fix

The resolved version is carried to the end and compared.

| condition | output |
|---|---|
| matches, or `--tarball` (no release names a version) | `Installed: looptroop <v>` — unchanged |
| differs | installed version, then which copy the shell will actually run, and how to find it |
| nothing answers | unchanged |

## Verified against the real condition

With 0.5.0 still shadowing on `PATH`:

```
Installed: looptroop 0.5.1

But `looptroop` on your PATH is 0.5.0, so another copy comes first.
Find it with: command -v looptroop
```

## Also

The README still said the three package managers were unpopulated — untrue since
0.5.1 published to them. It now describes the one way Chocolatey genuinely
differs: moderation makes it trail the other channels rather than arrive with them.

## Checks

`lint`, `typecheck`, `verify:version`, `verify:strip-types`, `installers:check`
pass. Full suite: 3220 passed, 2 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)