### PR TITLE
feat(winget): prove the portable shim on a real runner before offering it

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -343,19 +343,27 @@ jobs:
           set -euo pipefail
           node scripts/build-bundle.mjs --out "${RUNNER_TEMP}/bundle-a"
           node scripts/build-bundle.mjs --out "${RUNNER_TEMP}/bundle-b"
-          a=$(sha256sum "${RUNNER_TEMP}"/bundle-a/*.tar.gz | cut -d' ' -f1)
-          b=$(sha256sum "${RUNNER_TEMP}"/bundle-b/*.tar.gz | cut -d' ' -f1)
-          if [ "${a}" != "${b}" ]; then
-            echo "::error::Two builds of this commit produced different bundles (${a} vs ${b})."
-            exit 1
-          fi
-          echo "Reproducible: ${a}"
+          # Both archives, not only the tarball. The zip carries the same tree
+          # for WinGet, a manifest records its hash too, and ZIP is the format
+          # more likely to drift — it stores DOS local time rather than an
+          # epoch, so a timezone difference alone would move the digest.
+          for ext in tar.gz zip; do
+            a=$(sha256sum "${RUNNER_TEMP}"/bundle-a/*."${ext}" | cut -d' ' -f1)
+            b=$(sha256sum "${RUNNER_TEMP}"/bundle-b/*."${ext}" | cut -d' ' -f1)
+            if [ "${a}" != "${b}" ]; then
+              echo "::error::Two builds of this commit produced different .${ext} bundles (${a} vs ${b})."
+              exit 1
+            fi
+            echo "Reproducible .${ext}: ${a}"
+          done
 
       - name: Upload the bundle
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: bundle
-          path: ${{ runner.temp }}/bundle-a/*.tar.gz
+          path: |
+            ${{ runner.temp }}/bundle-a/*.tar.gz
+            ${{ runner.temp }}/bundle-a/*.zip
           if-no-files-found: error
           retention-days: 7
 
@@ -526,6 +534,49 @@ jobs:
         shell: bash
         run: node scripts/smoke-choco.ts --nupkg "$(ls "${RUNNER_TEMP}"/choco/*.nupkg)"
 
+  # WinGet, from manifests rendered here and a bundle served on loopback —
+  # never the public winget-pkgs repository. A submission there is a pull
+  # request reviewed by humans, so the package has to be proved before it is
+  # offered rather than after.
+  #
+  # The assumption this exists to test is that a `zip` carrying a `portable`
+  # pointing at `bin/looptroop.cmd` produces a working `looptroop`. Nothing else
+  # in the pipeline touches it, and it is not obvious: the archive holds a `#!`
+  # script, a `.cmd` and a `.ps1`, and only one of the three can be shimmed on
+  # Windows.
+  winget-install:
+    name: WinGet install (windows)
+    needs: [bundle]
+    runs-on: windows-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+        with:
+          node-version: 24.15.0
+
+      - name: Download the bundle
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: bundle
+          path: ${{ runner.temp }}/bundle
+
+      # Preinstalled on the Windows Server 2025 image, and not on 2022. Checked
+      # rather than assumed: if the runner image ever moves back, this job would
+      # otherwise fail with a confusing error deep inside the smoke script.
+      - name: Check winget is available
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          if (-not (Get-Command winget -ErrorAction SilentlyContinue)) {
+            Write-Error 'This runner image does not ship winget.'
+          }
+          winget --version
+
+      - name: Validate the manifests, install, run, and uninstall
+        shell: bash
+        run: node scripts/smoke-winget.ts --zip "$(ls "${RUNNER_TEMP}"/bundle/*.zip)"
+
   # Sufficient rather than merely cheaper: the defect this catches is code
   # choosing to write inside its own installation directory, and the code making
   # that choice is the same on all three platforms. What differs per platform is
@@ -607,7 +658,7 @@ jobs:
   # unconditional, so skipped means a dependency of theirs failed.
   packaging:
     name: Packaging
-    needs: [smoke-installer, bundle, bundle-runs, formula-audit, channel-install, choco-install]
+    needs: [smoke-installer, bundle, bundle-runs, formula-audit, channel-install, choco-install, winget-install]
     if: always()
     runs-on: ubuntu-latest
     timeout-minutes: 5

--- a/scripts/smoke-winget.ts
+++ b/scripts/smoke-winget.ts
@@ -1,0 +1,205 @@
+#!/usr/bin/env node
+/**
+ * Installs LoopTroop through WinGet from a local manifest, drives it, and
+ * uninstalls it again.
+ *
+ *   node scripts/smoke-winget.ts --zip dist-bundle/looptroop-9.9.9-bundle.zip
+ *
+ * From manifests rendered here and a bundle served on loopback, never the
+ * public `winget-pkgs` repository — the same trick the Homebrew and Scoop
+ * smokes use with a throwaway tap and bucket. A submission is a pull request
+ * into somebody else's repository and is reviewed by humans, so the package has
+ * to be proved before it is offered, not after.
+ *
+ * What this is really for is the one assumption the WinGet channel rests on:
+ * that a `zip` carrying a `portable` pointing at `bin/looptroop.cmd` produces a
+ * working `looptroop` command. Nothing else in the pipeline tests that, and it
+ * is not obvious — the archive holds a `#!` script, a `.cmd` and a `.ps1`, and
+ * only one of them can be shimmed on Windows.
+ */
+import { spawn } from 'node:child_process'
+import { createHash } from 'node:crypto'
+import { createReadStream, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { createServer } from 'node:http'
+import type { AddressInfo } from 'node:net'
+import { tmpdir } from 'node:os'
+import { basename, join, resolve } from 'node:path'
+import {
+  renderWingetManifests,
+  WINGET_IDENTIFIER,
+} from './package-manifests.ts'
+
+class SmokeError extends Error {
+  detail: string[]
+
+  constructor(message: string, detail: string[]) {
+    super(message)
+    this.name = 'SmokeError'
+    this.detail = detail
+  }
+}
+
+function fail(message: string, ...detail: string[]): never {
+  throw new SmokeError(message, detail.filter(Boolean))
+}
+
+function log(message: string): void {
+  process.stdout.write(`${message}\n`)
+}
+
+function flag(name: string, fallback: string | null = null): string {
+  const index = process.argv.indexOf(`--${name}`)
+  const value = index === -1 ? fallback : process.argv[index + 1]
+  if (value === undefined || value === null || value.startsWith('--')) fail(`--${name} is required.`)
+  return value
+}
+
+interface RunResult { code: number | null, stdout: string, stderr: string }
+
+/**
+ * Always async, never `spawnSync`.
+ *
+ * A synchronous child blocks this process's event loop, and this process is
+ * also the HTTP server the child downloads from — so a `spawnSync` here
+ * deadlocks and surfaces as a network timeout rather than as a hang.
+ */
+function invoke(command: string, args: string[], options: { env?: NodeJS.ProcessEnv, allowFailure?: boolean } = {}): Promise<RunResult> {
+  return new Promise((settle, reject) => {
+    const child = spawn(command, args, { env: { ...process.env, ...options.env } })
+    let stdout = ''
+    let stderr = ''
+    child.stdout.on('data', (chunk: Buffer) => { stdout += chunk.toString() })
+    child.stderr.on('data', (chunk: Buffer) => { stderr += chunk.toString() })
+    child.on('error', reject)
+    child.on('close', (code) => {
+      if (code !== 0 && options.allowFailure !== true) {
+        reject(new SmokeError(`${command} ${args.join(' ')} exited ${String(code)}.`, [stdout, stderr]))
+        return
+      }
+      settle({ code, stdout, stderr })
+    })
+  })
+}
+
+if (process.platform !== 'win32') fail('WinGet exists only on Windows.')
+
+const zipPath = resolve(flag('zip'))
+if (!existsSync(zipPath)) fail(`No bundle zip at ${zipPath}.`)
+
+const zipName = basename(zipPath)
+const version = /looptroop-(\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?)-bundle\.zip$/.exec(zipName)?.[1]
+  ?? fail(`Cannot read a version out of ${zipName}.`)
+const sha256 = createHash('sha256').update(readFileSync(zipPath)).digest('hex')
+
+const work = mkdtempSync(join(tmpdir(), 'looptroop-winget-'))
+const manifestDir = join(work, 'manifests')
+const configDir = join(work, 'config')
+const childEnv = { LOOPTROOP_CONFIG_DIR: configDir, LOOPTROOP_OPENCODE_MODE: 'mock' }
+
+/**
+ * A release-shaped path, so this exercises the URL a real manifest carries
+ * rather than a bare file name no release ever produces.
+ */
+const assetPath = `/looptroop-ai/LoopTroop/releases/download/v${version}/${zipName}`
+
+const server = createServer((request, response) => {
+  if (request.url !== assetPath) {
+    response.writeHead(404).end()
+    return
+  }
+  response.writeHead(200, { 'content-type': 'application/zip' })
+  createReadStream(zipPath).pipe(response)
+})
+
+/** Where WinGet puts the alias for a portable package. */
+const linkPath = join(
+  process.env.LOCALAPPDATA ?? join(process.env.USERPROFILE ?? 'C:\\', 'AppData', 'Local'),
+  'Microsoft', 'WinGet', 'Links', 'looptroop.exe',
+)
+
+async function main(): Promise<void> {
+  await new Promise<void>((done) => server.listen(0, '127.0.0.1', done))
+  const url = `http://127.0.0.1:${(server.address() as AddressInfo).port}${assetPath}`
+  log(`Serving ${zipName} at ${url}\n`)
+
+  mkdirSync(manifestDir, { recursive: true })
+  for (const [name, text] of Object.entries(renderWingetManifests({ version, url, sha256 }))) {
+    writeFileSync(join(manifestDir, name), text)
+  }
+  log(`Rendered ${Object.keys(renderWingetManifests({ version, url, sha256 })).length} manifests into ${manifestDir}`)
+
+  // Schema first. A manifest that does not validate is rejected by the
+  // submission pipeline before a human ever sees it, and the error there is
+  // far less legible than the one here.
+  const validated = await invoke('winget', ['validate', '--manifest', manifestDir], { allowFailure: true })
+  log(`${validated.stdout}${validated.stderr}`.trim())
+  if (validated.code !== 0) fail('`winget validate` rejected the rendered manifests.')
+  log('  manifests validate\n')
+
+  // `--skip-dependencies` deliberately. The declaration itself is covered by
+  // the golden files and by validation; what this proves is our archive and our
+  // shim. Letting WinGet resolve `OpenJS.NodeJS` here would install a second
+  // Node on a runner that already has one, cost minutes, and make this job
+  // depend on the public WinGet source being reachable.
+  log('Installing from the local manifest...')
+  await invoke('winget', [
+    'install', '--manifest', manifestDir,
+    '--accept-package-agreements', '--accept-source-agreements',
+    '--disable-interactivity', '--skip-dependencies',
+  ])
+
+  if (!existsSync(linkPath)) fail(`WinGet installed without producing an alias at ${linkPath}.`)
+  log(`  alias created at ${linkPath}`)
+
+  const reported = (await invoke(linkPath, ['--version'], { env: childEnv })).stdout.trim()
+  if (reported !== version) fail(`The installed command reports ${reported || '(nothing)'}, expected ${version}.`)
+  log(`  runs, and reports ${version}`)
+
+  // `doctor --json` rather than scraping the human report: this reads the
+  // install check itself instead of searching the whole output for two words
+  // that could co-occur in an unrelated remedy line.
+  const doctor = await invoke(linkPath, ['doctor', '--json'], { env: childEnv, allowFailure: true })
+  let checks: { name?: string, detail?: string }[]
+  try {
+    checks = JSON.parse(doctor.stdout).checks
+  } catch {
+    fail('`doctor --json` did not produce parseable JSON.', `${doctor.stdout}${doctor.stderr}`.slice(0, 3000))
+  }
+
+  const install = checks.find((check) => check.name === 'install')
+  if (!/^winget\b/.test(install?.detail ?? '')) {
+    fail(
+      '`doctor` does not report this as a winget install.',
+      `It reports: ${install?.detail ?? '(no install check)'}`,
+      'That means the upgrade command shown to the user is the wrong one.',
+    )
+  }
+  log(`  \`doctor\` reports the winget channel: ${install?.detail}`)
+
+  log('\nUninstalling...')
+  await invoke('winget', ['uninstall', WINGET_IDENTIFIER, '--disable-interactivity'])
+
+  if (existsSync(linkPath)) {
+    fail(
+      `Uninstalling left an alias behind at ${linkPath}.`,
+      'It will keep answering `looptroop` with a path that no longer exists.',
+    )
+  }
+  log('  alias removed')
+
+  log(`\nPASS: winget installs ${version} from a portable zip, it runs, it knows which `
+    + 'channel it came from, and uninstalling cleans up after itself.')
+}
+
+try {
+  await main()
+} catch (error) {
+  if (!(error instanceof SmokeError)) throw error
+  process.stderr.write(`\nFAIL: ${error.message}\n`)
+  for (const line of error.detail) process.stderr.write(`  ${line}\n`)
+  process.stderr.write('\n')
+  process.exitCode = 1
+} finally {
+  server.close()
+  rmSync(work, { recursive: true, force: true })
+}

--- a/server/lib/installChannel.ts
+++ b/server/lib/installChannel.ts
@@ -3,7 +3,7 @@ import { existsSync, readFileSync } from 'node:fs'
 import { fileURLToPath } from 'node:url'
 import { readSettingsFile, writeSettingsFile } from './appSettings'
 
-export type InstallChannel = 'npm' | 'homebrew' | 'scoop' | 'chocolatey' | 'container' | 'source' | 'unknown'
+export type InstallChannel = 'npm' | 'homebrew' | 'scoop' | 'chocolatey' | 'winget' | 'container' | 'source' | 'unknown'
 
 export interface InstallInfo {
   channel: InstallChannel
@@ -16,6 +16,9 @@ const UPGRADE_COMMANDS: Record<InstallChannel, string> = {
   homebrew: 'brew upgrade looptroop',
   scoop: 'scoop update looptroop',
   chocolatey: 'choco upgrade looptroop',
+  // `looptroop stop` first, because Windows will not replace a running
+  // executable and the daemon holds this one open.
+  winget: 'looptroop stop && winget upgrade LoopTroopAI.LoopTroop',
   container: 'docker pull looptroopai/looptroop:latest',
   source: 'git pull && npm install && npm run build',
   unknown: 'See https://www.looptroop.ovh for upgrade instructions',
@@ -98,6 +101,10 @@ function detectFromShape(moduleDir: string): InstallChannel {
   if (/\/Cellar\/looptroop\//i.test(normalized)) return 'homebrew'
   if (/\/scoop\/apps\/looptroop\//i.test(normalized)) return 'scoop'
   if (/\/ProgramData\/chocolatey\//i.test(normalized)) return 'chocolatey'
+  // WinGet unpacks a portable archive and runs nothing afterwards, so unlike
+  // the other three it cannot leave a marker file behind. The install path is
+  // the only evidence there is, and WinGet owns this directory outright.
+  if (/\/WinGet\/Packages\//i.test(normalized)) return 'winget'
   if (/\/node_modules\/looptroop\//.test(normalized)) return 'npm'
 
   // A checkout has the sources a published package never ships.

--- a/tests/updateCheck.test.ts
+++ b/tests/updateCheck.test.ts
@@ -43,6 +43,10 @@ describe('install channel detection', () => {
     ['/home/linuxbrew/.linuxbrew/Cellar/looptroop/9.9.9/libexec/dist/server/cli', 'homebrew'],
     ['/home/u/scoop/apps/looptroop/current/dist/server/cli', 'scoop'],
     ['/c/ProgramData/chocolatey/lib/looptroop/dist/server/cli', 'chocolatey'],
+    // WinGet unpacks a portable archive and runs nothing afterwards, so unlike
+    // the other three it cannot leave a marker file. The path is the only
+    // evidence, and WinGet owns this directory outright.
+    ['/c/Users/u/AppData/Local/Microsoft/WinGet/Packages/LoopTroopAI.LoopTroop_Microsoft.Winget.Source_8wekyb3d8bbwe/looptroop/dist/server/cli', 'winget'],
   ])('detects %s as %s', (moduleDir, expected) => {
     expect(detectInstallChannel(moduleDir)).toBe(expected)
   })


### PR DESCRIPTION
Stacked on #26. Second slice of Phase 6, and the one that tests the assumption the whole
channel rests on.

## The load-bearing assumption

That a `zip` carrying a `portable` pointing at `bin/looptroop.cmd` produces a working
`looptroop`. Nothing else in the pipeline touches it, and it isn't obvious — the archive
holds a `#!` script, a `.cmd` and a `.ps1`, and **only one of the three can be shimmed on
Windows**.

`smoke-winget.ts` runs the whole lifecycle from manifests rendered in the job and a bundle
served on loopback — never the public `winget-pkgs`. Same trick the Homebrew and Scoop
smokes use with a throwaway tap and bucket: a submission there is a human-reviewed pull
request, so the package must be proved *before* it is offered.

validate → install from local manifest → `--version` → `doctor --json` asserts the channel
→ uninstall → check no orphaned alias in WinGet's `Links`.

Async `spawn` throughout, never `spawnSync`: this process is also the HTTP server the child
downloads from, so a synchronous child deadlocks and surfaces as a network timeout.

`--skip-dependencies` deliberately — the declaration is covered by the goldens and by
validation; what this job proves is *our* archive and *our* shim. Resolving `OpenJS.NodeJS`
here would install a second Node on a runner that already has one and make the job depend
on the public WinGet source being reachable.

## A new install channel, because WinGet cannot leave a marker

Homebrew, Scoop and Chocolatey all run a script after unpacking and write
`.install-channel`. **A WinGet portable install unpacks an archive and runs nothing.** So
the path is the only evidence, and WinGet owns `.../WinGet/Packages/` outright.

Without this, `doctor` reports `unknown` and offers no upgrade command at all.

The upgrade command leads with `looptroop stop`:

```
looptroop stop && winget upgrade LoopTroopAI.LoopTroop
```

because Windows will not replace a running executable and the daemon holds that file open —
`winget upgrade` alone fails for anyone with LoopTroop running.

## Also

- The bundle artifact carries **both** archives, and the reproducibility gate compares both.
  ZIP is the likelier to drift: it stores DOS *local* time rather than an epoch, so a
  timezone difference alone would move the digest.
- `winget` is checked for explicitly — preinstalled on Windows Server 2025, absent on 2022 —
  so a runner image change fails with a clear message rather than deep inside the smoke.
- `winget-install` joins the **Packaging** gate, so it is required on main like the rest.

## Checks

`lint`, `typecheck`, `verify:strip-types` pass. Full suite: **3234 passed, 2 skipped**.

The Windows job itself is unproven until CI runs it — I have no Windows here, and the http
loopback `InstallerUrl` is the part most likely to need iteration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)