### PR TITLE
feat(bundle): check both archives for reproducibility, and detect WinGet installs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -343,19 +343,27 @@ jobs:
           set -euo pipefail
           node scripts/build-bundle.mjs --out "${RUNNER_TEMP}/bundle-a"
           node scripts/build-bundle.mjs --out "${RUNNER_TEMP}/bundle-b"
-          a=$(sha256sum "${RUNNER_TEMP}"/bundle-a/*.tar.gz | cut -d' ' -f1)
-          b=$(sha256sum "${RUNNER_TEMP}"/bundle-b/*.tar.gz | cut -d' ' -f1)
-          if [ "${a}" != "${b}" ]; then
-            echo "::error::Two builds of this commit produced different bundles (${a} vs ${b})."
-            exit 1
-          fi
-          echo "Reproducible: ${a}"
+          # Both archives, not only the tarball. The zip carries the same tree
+          # for WinGet, a manifest records its hash too, and ZIP is the format
+          # more likely to drift — it stores DOS local time rather than an
+          # epoch, so a timezone difference alone would move the digest.
+          for ext in tar.gz zip; do
+            a=$(sha256sum "${RUNNER_TEMP}"/bundle-a/*."${ext}" | cut -d' ' -f1)
+            b=$(sha256sum "${RUNNER_TEMP}"/bundle-b/*."${ext}" | cut -d' ' -f1)
+            if [ "${a}" != "${b}" ]; then
+              echo "::error::Two builds of this commit produced different .${ext} bundles (${a} vs ${b})."
+              exit 1
+            fi
+            echo "Reproducible .${ext}: ${a}"
+          done
 
       - name: Upload the bundle
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: bundle
-          path: ${{ runner.temp }}/bundle-a/*.tar.gz
+          path: |
+            ${{ runner.temp }}/bundle-a/*.tar.gz
+            ${{ runner.temp }}/bundle-a/*.zip
           if-no-files-found: error
           retention-days: 7
 

--- a/server/lib/installChannel.ts
+++ b/server/lib/installChannel.ts
@@ -3,7 +3,7 @@ import { existsSync, readFileSync } from 'node:fs'
 import { fileURLToPath } from 'node:url'
 import { readSettingsFile, writeSettingsFile } from './appSettings'
 
-export type InstallChannel = 'npm' | 'homebrew' | 'scoop' | 'chocolatey' | 'container' | 'source' | 'unknown'
+export type InstallChannel = 'npm' | 'homebrew' | 'scoop' | 'chocolatey' | 'winget' | 'container' | 'source' | 'unknown'
 
 export interface InstallInfo {
   channel: InstallChannel
@@ -16,6 +16,9 @@ const UPGRADE_COMMANDS: Record<InstallChannel, string> = {
   homebrew: 'brew upgrade looptroop',
   scoop: 'scoop update looptroop',
   chocolatey: 'choco upgrade looptroop',
+  // `looptroop stop` first, because Windows will not replace a running
+  // executable and the daemon holds this one open.
+  winget: 'looptroop stop && winget upgrade LoopTroopAI.LoopTroop',
   container: 'docker pull looptroopai/looptroop:latest',
   source: 'git pull && npm install && npm run build',
   unknown: 'See https://www.looptroop.ovh for upgrade instructions',
@@ -98,6 +101,10 @@ function detectFromShape(moduleDir: string): InstallChannel {
   if (/\/Cellar\/looptroop\//i.test(normalized)) return 'homebrew'
   if (/\/scoop\/apps\/looptroop\//i.test(normalized)) return 'scoop'
   if (/\/ProgramData\/chocolatey\//i.test(normalized)) return 'chocolatey'
+  // WinGet unpacks a portable archive and runs nothing afterwards, so unlike
+  // the other three it cannot leave a marker file behind. The install path is
+  // the only evidence there is, and WinGet owns this directory outright.
+  if (/\/WinGet\/Packages\//i.test(normalized)) return 'winget'
   if (/\/node_modules\/looptroop\//.test(normalized)) return 'npm'
 
   // A checkout has the sources a published package never ships.

--- a/tests/updateCheck.test.ts
+++ b/tests/updateCheck.test.ts
@@ -43,6 +43,10 @@ describe('install channel detection', () => {
     ['/home/linuxbrew/.linuxbrew/Cellar/looptroop/9.9.9/libexec/dist/server/cli', 'homebrew'],
     ['/home/u/scoop/apps/looptroop/current/dist/server/cli', 'scoop'],
     ['/c/ProgramData/chocolatey/lib/looptroop/dist/server/cli', 'chocolatey'],
+    // WinGet unpacks a portable archive and runs nothing afterwards, so unlike
+    // the other three it cannot leave a marker file. The path is the only
+    // evidence, and WinGet owns this directory outright.
+    ['/c/Users/u/AppData/Local/Microsoft/WinGet/Packages/LoopTroopAI.LoopTroop_Microsoft.Winget.Source_8wekyb3d8bbwe/looptroop/dist/server/cli', 'winget'],
   ])('detects %s as %s', (moduleDir, expected) => {
     expect(detectInstallChannel(moduleDir)).toBe(expected)
   })


### PR DESCRIPTION
Split out of the WinGet channel work after `winget validate` refused the approach on a real
runner. These two pieces stand on their own; the rest waits for a Windows `.exe`.

## What CI told us

```
Manifest Error: The file type of the referenced file is not allowed.
[RelativeFilePath] Value: looptroop\bin\looptroop.cmd
```

The winget-pkgs validation pipeline requires a portable's `RelativeFilePath` inside a zip to
be a **`.exe`**. The winget *client* does support `.cmd` — but the repository's validation
does not, and the local `winget validate` enforces it too.

**So WinGet does need a binary after all**, by a completely different mechanism than the
dependency question the plan analysed. The WinGet CI job and `smoke-winget.ts` are withdrawn
until the standalone binaries land, and return pointing at the `.exe`.

## Both archives are reproducibility-checked

The bundle zip became a release asset in #26 and a manifest records its hash, so leaving it
out of the two-build comparison was a gap. ZIP is also the likelier to drift — it stores DOS
*local* time rather than an epoch, so a timezone difference alone moves the digest. The
artifact now carries both.

## A `winget` install channel

Homebrew, Scoop and Chocolatey each run a script after unpacking and write
`.install-channel`. **A WinGet portable install unpacks an archive and runs nothing**, so
there is nowhere to write a marker and the path is the only evidence. WinGet owns
`.../WinGet/Packages/` outright.

Without this, a WinGet install reports `unknown` and gets no upgrade command at all. The one
it reports leads with `looptroop stop`:

```
looptroop stop && winget upgrade LoopTroopAI.LoopTroop
```

because Windows will not replace a running executable and the daemon holds that file open.

## Checks

`lint`, `typecheck`, `verify:strip-types` pass. Full suite: 3234 passed, 2 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)