### PR TITLE
feat(sea): make the application survive a single-file build, and prove it

### DIFF
--- a/.github/workflows/channel-republish.yml
+++ b/.github/workflows/channel-republish.yml
@@ -49,7 +49,7 @@ on:
         description: 'Which channel to republish'
         required: true
         type: choice
-        options: [homebrew, scoop, chocolatey]
+        options: [homebrew, scoop, chocolatey, winget]
       force:
         description: 'Replace this version in place. Only for a descriptor that was published wrong.'
         required: false
@@ -82,6 +82,9 @@ jobs:
       sha256: ${{ steps.inputs.outputs.sha256 }}
       force: ${{ steps.force.outputs.force }}
       templates: ${{ steps.templates.outputs.ref }}
+      win_binary: ${{ steps.inputs.outputs.win_binary }}
+      win_binary_url: ${{ steps.inputs.outputs.win_binary_url }}
+      win_binary_sha256: ${{ steps.inputs.outputs.win_binary_sha256 }}
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
@@ -400,3 +403,56 @@ jobs:
         run: >
           node scripts/smoke-choco.ts --from-feed
           --version "${{ needs.prepare.outputs.version }}"
+
+  # ---------------------------------------------------------------------------
+  # WinGet, whose recovery is a pull request rather than a write.
+  # ---------------------------------------------------------------------------
+  # The submission is retry-safe by construction — it reconciles with an open
+  # pull request for this version rather than opening a second — so this job is
+  # simply the same submission run again, for a release whose WinGet job failed
+  # or was skipped for want of a credential.
+  #
+  # Nothing here can make Microsoft merge it. Like Chocolatey moderation, that
+  # is a queue this workflow reports into and never waits on.
+  winget:
+    name: Resubmit the WinGet manifests
+    needs: [prepare]
+    if: inputs.channel == 'winget'
+    runs-on: windows-latest
+    timeout-minutes: 30
+    environment: packaging
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+          # The release's own templates, not the default branch's. See `prepare`.
+          ref: ${{ needs.prepare.outputs.templates }}
+
+      - name: Set up Node
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+        with:
+          node-version: 24.15.0
+
+      - name: Submit the manifests
+        shell: bash
+        env:
+          WINGET_TOKEN: ${{ secrets.WINGET_TOKEN }}
+          VERSION: ${{ needs.prepare.outputs.version }}
+          WIN_BINARY: ${{ needs.prepare.outputs.win_binary }}
+          WIN_BINARY_URL: ${{ needs.prepare.outputs.win_binary_url }}
+          WIN_BINARY_SHA256: ${{ needs.prepare.outputs.win_binary_sha256 }}
+        run: |
+          set -euo pipefail
+          if [ -z "${WINGET_TOKEN:-}" ]; then
+            echo "::error::WINGET_TOKEN is not set in the packaging environment."
+            exit 1
+          fi
+          if [ -z "${WIN_BINARY}" ]; then
+            echo "::error::v${VERSION} carries no Windows binary; it predates the WinGet channel."
+            exit 1
+          fi
+          node scripts/winget-submit.ts \
+            --version "${VERSION}" \
+            --url "${WIN_BINARY_URL}" \
+            --sha256 "${WIN_BINARY_SHA256}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -534,6 +534,81 @@ jobs:
         shell: bash
         run: node scripts/smoke-choco.ts --nupkg "$(ls "${RUNNER_TEMP}"/choco/*.nupkg)"
 
+
+  # The standalone binaries: LoopTroop with a Node runtime inside it, for
+  # machines that have none. Built on the runner that matches the target,
+  # because a SEA embeds the running Node and a cross-built one would carry the
+  # wrong runtime.
+  #
+  # macOS x64 is absent deliberately: Node supports single-executable
+  # applications on arm64 only there, so Intel Macs keep Homebrew and npm.
+  binary:
+    name: Binary (${{ matrix.target }})
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 40
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { os: ubuntu-latest, target: linux-x64 }
+          - { os: ubuntu-24.04-arm, target: linux-arm64 }
+          - { os: macos-14, target: darwin-arm64 }
+          - { os: windows-latest, target: win-x64 }
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+        with:
+          node-version: 24.15.0
+          cache: npm
+
+      - name: Pin npm to the declared version
+        run: node scripts/pin-npm.mjs
+        shell: bash
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build application
+        run: npm run build
+
+      # Twice, requiring identical bytes. The SEA blob embeds the absolute path
+      # of the script it was built from, which made the first version of this
+      # non-reproducible for a reason nothing downstream would have explained —
+      # a manifest records this hash and the descriptors point at it.
+      - name: Build the binary twice and require identical bytes
+        shell: bash
+        run: |
+          set -euo pipefail
+          node scripts/build-binary.mjs --out "${RUNNER_TEMP}/bin-a"
+          node scripts/build-binary.mjs --out "${RUNNER_TEMP}/bin-b"
+          a=$(openssl dgst -sha256 -r "${RUNNER_TEMP}"/bin-a/looptroop-*-${{ matrix.target }}* | cut -d' ' -f1 | sort | tr -d '\n')
+          b=$(openssl dgst -sha256 -r "${RUNNER_TEMP}"/bin-b/looptroop-*-${{ matrix.target }}* | cut -d' ' -f1 | sort | tr -d '\n')
+          if [ "${a}" != "${b}" ]; then
+            echo "::error::Two builds of this commit produced different binaries."
+            exit 1
+          fi
+          echo "Reproducible."
+
+      # With Node removed from PATH, which is the only thing that proves the
+      # claim: every runner has Node, so a binary that quietly used it would
+      # pass any weaker test and fail for the user this artefact exists for.
+      - name: Unpack it and drive it with no Node installed
+        shell: bash
+        run: |
+          set -euo pipefail
+          archive=$(ls "${RUNNER_TEMP}"/bin-a/looptroop-*-${{ matrix.target }}.tar.gz "${RUNNER_TEMP}"/bin-a/looptroop-*-${{ matrix.target }}.zip 2>/dev/null | head -1)
+          node scripts/smoke-binary.mjs --archive "${archive}"
+
+      - name: Upload the archive
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: binary-${{ matrix.target }}
+          path: |
+            ${{ runner.temp }}/bin-a/*.tar.gz
+            ${{ runner.temp }}/bin-a/*.zip
+          if-no-files-found: error
+          retention-days: 7
+
   # Sufficient rather than merely cheaper: the defect this catches is code
   # choosing to write inside its own installation directory, and the code making
   # that choice is the same on all three platforms. What differs per platform is
@@ -615,7 +690,7 @@ jobs:
   # unconditional, so skipped means a dependency of theirs failed.
   packaging:
     name: Packaging
-    needs: [smoke-installer, bundle, bundle-runs, formula-audit, channel-install, choco-install]
+    needs: [smoke-installer, bundle, bundle-runs, formula-audit, channel-install, choco-install, binary]
     if: always()
     runs-on: ubuntu-latest
     timeout-minutes: 5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -663,6 +663,17 @@ jobs:
           }
           winget --version
 
+      # Installing from a local manifest is off by default and has to be enabled
+      # explicitly; without it winget rejects `--manifest` as an invalid
+      # argument and prints its help, which reads like a malformed command
+      # rather than a missing setting. Needs administrator rights, which the
+      # runner has.
+      - name: Allow installing from a local manifest
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          winget settings --enable LocalManifestFiles
+
       - name: Validate the manifests, install, run, and uninstall
         shell: bash
         run: node scripts/smoke-winget.ts --archive "$(ls "${RUNNER_TEMP}"/binary/*.zip)"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -596,7 +596,14 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          archive=$(ls "${RUNNER_TEMP}"/bin-a/looptroop-*-${{ matrix.target }}.tar.gz "${RUNNER_TEMP}"/bin-a/looptroop-*-${{ matrix.target }}.zip 2>/dev/null | head -1)
+          # `find`, not `ls` with two globs: one of them never matches — the
+          # archive is a tarball or a zip, never both — and `ls` exits 2 for the
+          # miss, which `set -e` turns into a job failure before the script runs.
+          archive=$(find "${RUNNER_TEMP}/bin-a" -maxdepth 1 \( -name 'looptroop-*.tar.gz' -o -name 'looptroop-*.zip' \) | head -1)
+          if [ -z "${archive}" ]; then
+            echo "::error::The build produced no archive in ${RUNNER_TEMP}/bin-a."
+            exit 1
+          fi
           node scripts/smoke-binary.mjs --archive "${archive}"
 
       - name: Upload the archive
@@ -608,6 +615,50 @@ jobs:
             ${{ runner.temp }}/bin-a/*.zip
           if-no-files-found: error
           retention-days: 7
+
+
+  # WinGet, from manifests rendered in the job and the Windows binary archive
+  # served on loopback — never the public winget-pkgs repository. A submission
+  # there is a human-reviewed pull request, so the package is proved before it
+  # is offered rather than after.
+  #
+  # This channel installs the standalone binary rather than the bundle the
+  # other three take, and not by preference: `winget validate` refuses a
+  # portable whose `RelativeFilePath` is anything but an `.exe`, and rejected
+  # the bundle's `.cmd` shim outright. Keeping that rejection caught here is
+  # most of why this job exists.
+  winget-install:
+    name: WinGet install (windows)
+    needs: [binary]
+    runs-on: windows-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+        with:
+          node-version: 24.15.0
+
+      - name: Download the Windows binary
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: binary-win-x64
+          path: ${{ runner.temp }}/binary
+
+      # Preinstalled on the Windows Server 2025 image and absent from 2022.
+      # Checked rather than assumed, so a runner image change fails with a clear
+      # message instead of deep inside the smoke script.
+      - name: Check winget is available
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          if (-not (Get-Command winget -ErrorAction SilentlyContinue)) {
+            Write-Error 'This runner image does not ship winget.'
+          }
+          winget --version
+
+      - name: Validate the manifests, install, run, and uninstall
+        shell: bash
+        run: node scripts/smoke-winget.ts --archive "$(ls "${RUNNER_TEMP}"/binary/*.zip)"
 
   # Sufficient rather than merely cheaper: the defect this catches is code
   # choosing to write inside its own installation directory, and the code making
@@ -690,7 +741,7 @@ jobs:
   # unconditional, so skipped means a dependency of theirs failed.
   packaging:
     name: Packaging
-    needs: [smoke-installer, bundle, bundle-runs, formula-audit, channel-install, choco-install, binary]
+    needs: [smoke-installer, bundle, bundle-runs, formula-audit, channel-install, choco-install, binary, winget-install]
     if: always()
     runs-on: ubuntu-latest
     timeout-minutes: 5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -571,6 +571,13 @@ jobs:
       - name: Build application
         run: npm run build
 
+      # macOS ships bsdtar as `tar`, and the reproducible flags the archive
+      # needs — `--sort`, `--mtime`, the pax options — are GNU extensions it
+      # rejects.
+      - name: Install GNU tar
+        if: runner.os == 'macOS'
+        run: brew install gnu-tar
+
       # Twice, requiring identical bytes. The SEA blob embeds the absolute path
       # of the script it was built from, which made the first version of this
       # non-reproducible for a reason nothing downstream would have explained —

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -216,6 +216,10 @@ jobs:
     if: needs.detect.outputs.proceed == 'true'
     runs-on: ${{ matrix.os }}
     timeout-minutes: 40
+    permissions:
+      contents: read
+      id-token: write
+      attestations: write
     strategy:
       fail-fast: false
       matrix:
@@ -268,6 +272,20 @@ jobs:
             exit 1
           fi
           node scripts/smoke-binary.mjs --archive "${archive}"
+
+      # Provenance: a signed statement that these bytes came from this workflow,
+      # this repository and this commit. It is what we ship instead of code
+      # signing, which was declined, and it is free.
+      #
+      # `contents: read` is listed alongside the two the action needs because a
+      # job-level block *replaces* the workflow default rather than adding to
+      # it — anything unlisted becomes `none`, and the checkout would fail.
+      - name: Attest the archive
+        uses: actions/attest-build-provenance@977bb373ede98d70efdf65b84cb5f73e068dcc2a # v3
+        with:
+          subject-path: |
+            ${{ runner.temp }}/binary/*.tar.gz
+            ${{ runner.temp }}/binary/*.zip
 
       - name: Upload the archive
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -199,11 +199,92 @@ jobs:
           esac
 
   # ---------------------------------------------------------------------------
+  # The standalone binaries, before anything is packed.
+  # ---------------------------------------------------------------------------
+  # Each target is built on the runner that matches it: a single-file build
+  # embeds the running Node, so a cross-built one would carry the wrong runtime.
+  # macOS x64 is absent because Node supports single-executable applications on
+  # arm64 only there; Intel Macs keep Homebrew and npm.
+  #
+  # These gate `build` rather than running beside it, because the release
+  # manifest has to record their checksums — WinGet's descriptor points at the
+  # win-x64 archive by URL and hash, and that hash has exactly one source of
+  # truth.
+  binary:
+    name: Binary (${{ matrix.target }})
+    needs: [detect]
+    if: needs.detect.outputs.proceed == 'true'
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 40
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { os: ubuntu-latest, target: linux-x64 }
+          - { os: ubuntu-24.04-arm, target: linux-arm64 }
+          - { os: macos-14, target: darwin-arm64 }
+          - { os: windows-latest, target: win-x64 }
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+
+      - name: Set up Node
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+        with:
+          node-version: 24.15.0
+          cache: npm
+
+      - name: Pin npm to the declared version
+        run: node scripts/pin-npm.mjs
+        shell: bash
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build application
+        run: npm run build
+
+      # macOS ships bsdtar as `tar`, which rejects the reproducible flags.
+      - name: Install GNU tar
+        if: runner.os == 'macOS'
+        run: brew install gnu-tar
+
+      - name: Build the binary
+        run: node scripts/build-binary.mjs --out "${{ runner.temp }}/binary"
+        shell: bash
+
+      # With `node` shadowed, which is the only thing that proves the artefact:
+      # every runner has Node, so a binary that quietly used it would pass any
+      # weaker check and fail for the user this exists for.
+      - name: Drive it with no Node available
+        shell: bash
+        run: |
+          set -euo pipefail
+          archive=$(find "${RUNNER_TEMP}/binary" -maxdepth 1 \( -name 'looptroop-*.tar.gz' -o -name 'looptroop-*.zip' \) | head -1)
+          if [ -z "${archive}" ]; then
+            echo "::error::The build produced no archive."
+            exit 1
+          fi
+          node scripts/smoke-binary.mjs --archive "${archive}"
+
+      - name: Upload the archive
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: release-binary-${{ matrix.target }}
+          path: |
+            ${{ runner.temp }}/binary/*.tar.gz
+            ${{ runner.temp }}/binary/*.zip
+          if-no-files-found: error
+          retention-days: 14
+
+  # ---------------------------------------------------------------------------
   # Pack exactly once. Everything downstream consumes these bytes.
   # ---------------------------------------------------------------------------
   build:
     name: Build and pack
-    needs: [detect]
+    needs: [detect, binary]
     if: needs.detect.outputs.proceed == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 25
@@ -267,6 +348,15 @@ jobs:
       # digests and refuses to proceed on a mismatch, so a corrupted or
       # substituted artefact download fails loudly before it reaches npm rather
       # than being detected afterwards, when the publish is already permanent.
+      # Every target's archive, into the directory the manifest is written from.
+      # `merge-multiple` because each target uploaded its own artefact and they
+      # are all part of one release.
+      - name: Collect the standalone binaries
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          pattern: release-binary-*
+          merge-multiple: true
+
       - name: Write the release manifest
         id: manifest
         run: |
@@ -277,8 +367,21 @@ jobs:
           # Scoop and Chocolatey fetch; the zip exists because WinGet's archive
           # installer type reads ZIP and nothing else.
           zip="looptroop-${{ needs.detect.outputs.version }}-bundle.zip"
+          # The binaries are named per target and there is one manifest, so they
+          # are collected by glob rather than listed: a target added later must
+          # not need this line edited, and a target that failed to upload must
+          # be a missing asset rather than a silent omission.
+          binaries=()
+          while IFS= read -r file; do binaries+=(--asset "${file}"); done < <(
+            find . -maxdepth 1 \( -name 'looptroop-*-linux-*.tar.gz' -o -name 'looptroop-*-darwin-*.tar.gz' -o -name 'looptroop-*-win-*.zip' \) | sort
+          )
+          if [ "${#binaries[@]}" -eq 0 ]; then
+            echo "::error::No standalone binaries were collected; the manifest would omit them."
+            exit 1
+          fi
           npm run release:manifest -- "${tarball}" \
-            --asset "${bundle}" --asset "${zip}" --asset install.sh --asset install.ps1
+            --asset "${bundle}" --asset "${zip}" --asset install.sh --asset install.ps1 \
+            "${binaries[@]}"
           node -e '
             const m = JSON.parse(require("node:fs").readFileSync("release-manifest.json","utf8"))
             const out = require("node:fs").createWriteStream(process.env.GITHUB_OUTPUT,{flags:"a"})
@@ -301,6 +404,10 @@ jobs:
           path: |
             looptroop-*.tgz
             looptroop-*-bundle.tar.gz
+            looptroop-*-bundle.zip
+            looptroop-*-linux-*.tar.gz
+            looptroop-*-darwin-*.tar.gz
+            looptroop-*-win-*.zip
             install.sh
             install.ps1
             release-manifest.json
@@ -1569,6 +1676,78 @@ jobs:
           --nupkg "dist-choco/looptroop.${{ steps.inputs.outputs.version }}.nupkg"
           --version "${{ steps.inputs.outputs.version }}"
 
+  # ---------------------------------------------------------------------------
+  # WinGet, which is a pull request into somebody else's repository.
+  # ---------------------------------------------------------------------------
+  # Not a write we control: it is a submission into `microsoft/winget-pkgs`,
+  # reviewed by humans on their schedule. So it is reported as *submitted* and
+  # gates nothing, exactly as Chocolatey is.
+  #
+  # It installs the standalone binary rather than the bundle, and not by
+  # preference: a portable's `RelativeFilePath` must be an `.exe`, and
+  # `winget validate` rejects anything else outright.
+  #
+  # Skipped rather than failed while `WINGET_TOKEN` is unset, so the channel can
+  # land before the credential exists without turning every release red.
+  publish-winget:
+    name: Publish to WinGet
+    needs: [detect, build, finalize]
+    if: >-
+      needs.detect.outputs.proceed == 'true'
+      && needs.detect.outputs.dry_run == 'false'
+      && needs.detect.outputs.dist_tag == 'latest'
+    runs-on: windows-latest
+    timeout-minutes: 30
+    environment: packaging
+    outputs:
+      state: ${{ steps.submit.outputs.state }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+
+      - name: Set up Node
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+        with:
+          node-version: 24.15.0
+
+      - name: Download the release artefacts
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: release-artefacts
+
+      - name: Read what this release publishes
+        id: inputs
+        shell: bash
+        run: node scripts/channel-inputs.ts --manifest release-manifest.json --repo "${GITHUB_REPOSITORY}"
+
+      - name: Submit the manifests
+        id: submit
+        shell: bash
+        env:
+          WINGET_TOKEN: ${{ secrets.WINGET_TOKEN }}
+          WIN_BINARY: ${{ steps.inputs.outputs.win_binary }}
+          WIN_BINARY_URL: ${{ steps.inputs.outputs.win_binary_url }}
+          WIN_BINARY_SHA256: ${{ steps.inputs.outputs.win_binary_sha256 }}
+          VERSION: ${{ steps.inputs.outputs.version }}
+        run: |
+          set -euo pipefail
+          if [ -z "${WINGET_TOKEN:-}" ]; then
+            echo "state=skipped" >> "$GITHUB_OUTPUT"
+            echo "::warning::WINGET_TOKEN is not set; the WinGet submission was skipped."
+            exit 0
+          fi
+          if [ -z "${WIN_BINARY}" ]; then
+            echo "::error::This release carries no Windows binary, so WinGet cannot be published."
+            exit 1
+          fi
+          node scripts/winget-submit.ts \
+            --version "${VERSION}" \
+            --url "${WIN_BINARY_URL}" \
+            --sha256 "${WIN_BINARY_SHA256}"
+          echo "state=submitted" >> "$GITHUB_OUTPUT"
+
   report:
     name: Report
     needs:
@@ -1587,6 +1766,7 @@ jobs:
       - publish-homebrew
       - publish-scoop
       - publish-chocolatey
+      - publish-winget
     if: always() && needs.detect.outputs.proceed == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 10
@@ -1617,6 +1797,8 @@ jobs:
           R_SCOOP: ${{ needs.publish-scoop.result }}
           R_CHOCO: ${{ needs.publish-chocolatey.result }}
           CHOCO_STATE: ${{ needs.publish-chocolatey.outputs.state }}
+          R_WINGET: ${{ needs.publish-winget.result }}
+          WINGET_STATE: ${{ needs.publish-winget.outputs.state }}
           INDEX_DIGEST: ${{ needs.container-manifest.outputs.index_digest }}
           CONTAINER_TAGS: ${{ needs.container-manifest.outputs.tags }}
           SHA256: ${{ needs.build.outputs.sha256 }}
@@ -1654,6 +1836,7 @@ jobs:
             printf 'homebrew   %s\n' "${R_BREW}"
             printf 'scoop      %s\n' "${R_SCOOP}"
             printf 'chocolatey %s  %s\n' "${R_CHOCO}" "${CHOCO_STATE:-—}"
+            printf 'winget     %s  %s\n' "${R_WINGET}" "${WINGET_STATE:-—}"
             echo '```'
             echo
             echo "Integrity: \`${INTEGRITY}\`"
@@ -1671,7 +1854,8 @@ jobs:
                       "container-build:${R_CBUILD}" "container-manifest:${R_CMANIFEST}" \
                       "container-verify:${R_CVERIFY}" "container-notes:${R_CNOTES}" \
                       "publish-homebrew:${R_BREW}" "publish-scoop:${R_SCOOP}" \
-                      "publish-chocolatey:${R_CHOCO}"; do
+                      "publish-chocolatey:${R_CHOCO}" \
+                      "publish-winget:${R_WINGET}"; do
             name=${pair%%:*}
             result=${pair#*:}
             case "${result}" in

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,14 +9,26 @@
       "version": "0.5.1",
       "license": "MIT",
       "dependencies": {
+        "@hono/node-server": "^2.0.12",
+        "@opencode-ai/sdk": "^1.18.13",
+        "drizzle-orm": "1.0.0-rc.4",
+        "gpt-tokenizer": "^3.4.0",
+        "hono": "^4.12.31",
+        "js-yaml": "^5.2.2",
+        "xstate": "^5.32.5",
+        "zod": "^4.4.3"
+      },
+      "bin": {
+        "looptroop": "dist/server/cli/launcher.cjs"
+      },
+      "devDependencies": {
         "@codemirror/autocomplete": "^6.20.3",
         "@codemirror/lang-yaml": "^6.1.3",
         "@codemirror/language": "^6.12.4",
         "@codemirror/merge": "^6.12.2",
         "@codemirror/state": "^6.7.1",
         "@codemirror/view": "^6.43.7",
-        "@hono/node-server": "^2.0.12",
-        "@opencode-ai/sdk": "^1.18.13",
+        "@eslint/js": "^10.0.1",
         "@radix-ui/react-dialog": "^1.1.20",
         "@radix-ui/react-dropdown-menu": "^2.1.21",
         "@radix-ui/react-hover-card": "^1.1.20",
@@ -24,24 +36,8 @@
         "@radix-ui/react-separator": "^1.1.12",
         "@radix-ui/react-slot": "^1.3.0",
         "@radix-ui/react-tooltip": "^1.2.13",
-        "@tanstack/react-query": "^5.101.3",
-        "class-variance-authority": "^0.7.1",
-        "clsx": "^2.1.1",
-        "drizzle-orm": "1.0.0-rc.4",
-        "gpt-tokenizer": "^3.4.0",
-        "hono": "^4.12.31",
-        "js-yaml": "^5.2.2",
-        "lucide-react": "^1.27.0",
-        "react": "^19.2.8",
-        "react-dom": "^19.2.8",
-        "react-virtuoso": "4.18.11",
-        "tailwind-merge": "^3.6.0",
-        "xstate": "^5.32.5",
-        "zod": "^4.4.3"
-      },
-      "devDependencies": {
-        "@eslint/js": "^10.0.1",
         "@tailwindcss/vite": "^4.3.3",
+        "@tanstack/react-query": "^5.101.3",
         "@testing-library/jest-dom": "^7.0.0",
         "@testing-library/react": "^16.3.2",
         "@types/node": "^24.9.5",
@@ -49,6 +45,8 @@
         "@types/react": "^19.2.17",
         "@types/react-dom": "^19.2.3",
         "@vitejs/plugin-react": "^6.0.4",
+        "class-variance-authority": "^0.7.1",
+        "clsx": "^2.1.1",
         "concurrently": "^10.0.4",
         "drizzle-kit": "1.0.0-rc.4",
         "esbuild": "0.28.1",
@@ -57,7 +55,13 @@
         "eslint-plugin-react-refresh": "^0.5.3",
         "globals": "^17.8.0",
         "jsdom": "^30.0.0",
+        "lucide-react": "^1.27.0",
+        "postject": "1.0.0-alpha.6",
         "qrcode": "^1.5.4",
+        "react": "^19.2.8",
+        "react-dom": "^19.2.8",
+        "react-virtuoso": "4.18.11",
+        "tailwind-merge": "^3.6.0",
         "tailwindcss": "^4.3.3",
         "ts-morph": "^28.0.0",
         "ts-node": "^10.9.2",
@@ -399,6 +403,7 @@
       "version": "6.20.3",
       "resolved": "https://registry.npmjs.org/@codemirror/autocomplete/-/autocomplete-6.20.3.tgz",
       "integrity": "sha512-tlosUqb+3BbxCxZdu4tKeRghPFC+QM7q4X5YhKV2eCmPG+1r2F3f4AaSz5sCrFqUtX4Jh20VFTKecl16MgiV9g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@codemirror/language": "^6.0.0",
@@ -411,6 +416,7 @@
       "version": "6.1.3",
       "resolved": "https://registry.npmjs.org/@codemirror/lang-yaml/-/lang-yaml-6.1.3.tgz",
       "integrity": "sha512-AZ8DJBuXGVHybpBQhmZtgew5//4hv3tdkXnr3vDmOUMJRuB6vn/uuwtmTOTlqEaQFg3hQSVeA90NmvIQyUV6FQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@codemirror/autocomplete": "^6.0.0",
@@ -426,6 +432,7 @@
       "version": "6.12.4",
       "resolved": "https://registry.npmjs.org/@codemirror/language/-/language-6.12.4.tgz",
       "integrity": "sha512-1q4PaT+o6PbgpkJt4Q8Fv5XJxTy4FUZ4MWETtyiDw3J0Pyr9E2vqcKL+k9wcvjNTIsauxvE7OfmWj3FRPHQ76A==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@codemirror/state": "^6.0.0",
@@ -440,6 +447,7 @@
       "version": "6.12.2",
       "resolved": "https://registry.npmjs.org/@codemirror/merge/-/merge-6.12.2.tgz",
       "integrity": "sha512-V8JvyAPjHbPupqP7BeMcsdsYCbyPij74jxIbaIJDORI+VZzW44zFmon8bF+oxGWvOKhcRmkiUMXd8MxHr3YA2w==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@codemirror/language": "^6.0.0",
@@ -453,6 +461,7 @@
       "version": "6.7.1",
       "resolved": "https://registry.npmjs.org/@codemirror/state/-/state-6.7.1.tgz",
       "integrity": "sha512-9QzNDgE4EYDnAHfrTlR2lwiPciiOymLtwKK+8yHQzCc7GXhAP9xdEbEJFy2IWB1j9UGUl9BsgMmTo/ImA02T7A==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@marijn/find-cluster-break": "^1.0.0"
@@ -462,6 +471,7 @@
       "version": "6.43.7",
       "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.43.7.tgz",
       "integrity": "sha512-FZsExxkoxnAN+d9TgqXLg5g4A1oQwzX9WlkOT5i2PKkcW7xx3Bmu0vs90g6fo9Mpdsb/l96dnAraQ8932aO4/g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@codemirror/state": "^6.7.0",
@@ -1267,6 +1277,7 @@
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.8.0.tgz",
       "integrity": "sha512-0CIZ5itps/8x7BG8dEIhs53BvCUH2PCoogtakwRTut+Arm58sJooJ0AuZhLw2HJYIR5cMLNPBSS728sPho2khQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@floating-ui/utils": "^0.2.12"
@@ -1276,6 +1287,7 @@
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.8.0.tgz",
       "integrity": "sha512-yXSrzeHZBTZadLOlfyhCkJHNeLJnHRnRInwdZ40L7ZiaAtrBwoYlsDrX3v5zB1Utk7CLfzcOVnVVWoXEky7Ceg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@floating-ui/core": "^1.8.0",
@@ -1286,6 +1298,7 @@
       "version": "2.1.9",
       "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.9.tgz",
       "integrity": "sha512-JDjEFGCpImxDCA7JJKviA0M9+RtmJdj0m/NVU5IMgBK+AmZouAQQ7/+2GLH0GXXY0YMw9oXPB8hKdbPYg5QLYg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@floating-ui/dom": "^1.8.0"
@@ -1299,6 +1312,7 @@
       "version": "0.2.12",
       "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.12.tgz",
       "integrity": "sha512-HpCo8tmWzLVad5s2d19EhAz5zqrrQ6s69qd6moPMQvkOuSwDT1YgRfWSVuc4ennqrgv3OHppiOGMQ7oC13yIww==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@hono/node-server": {
@@ -1432,12 +1446,14 @@
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/@lezer/common/-/common-1.5.1.tgz",
       "integrity": "sha512-6YRVG9vBkaY7p1IVxL4s44n5nUnaNnGM2/AckNgYOnxTG2kWh1vR8BMxPseWPjRNpb5VtXnMpeYAEAADoRV1Iw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@lezer/highlight": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/@lezer/highlight/-/highlight-1.2.3.tgz",
       "integrity": "sha512-qXdH7UqTvGfdVBINrgKhDsVTJTxactNNxLk7+UMwZhU13lMHaOBlJe9Vqp907ya56Y3+ed2tlqzys7jDkTmW0g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@lezer/common": "^1.3.0"
@@ -1447,6 +1463,7 @@
       "version": "1.4.8",
       "resolved": "https://registry.npmjs.org/@lezer/lr/-/lr-1.4.8.tgz",
       "integrity": "sha512-bPWa0Pgx69ylNlMlPvBPryqeLYQjyJjqPx+Aupm5zydLIF3NE+6MMLT8Yi23Bd9cif9VS00aUebn+6fDIGBcDA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@lezer/common": "^1.0.0"
@@ -1456,6 +1473,7 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/@lezer/yaml/-/yaml-1.0.4.tgz",
       "integrity": "sha512-2lrrHqxalACEbxIbsjhqGpSW8kWpUKuY6RHgnSAFZa6qK62wvnPxA8hGOwOoDbwHcOFs5M4o27mjGu+P7TvBmw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@lezer/common": "^1.2.0",
@@ -1467,6 +1485,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@marijn/find-cluster-break/-/find-cluster-break-1.0.2.tgz",
       "integrity": "sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@napi-rs/wasm-runtime": {
@@ -1511,18 +1530,21 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/@radix-ui/number/-/number-1.1.3.tgz",
       "integrity": "sha512-Road2bidD0uu/1BGDOWNdPI06g0lIRy6IF9GZcIrDK2KGItfor8IQwQa+yM2ERgHM1MmHxaxpTzk0/Jp42lNfA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@radix-ui/primitive": {
       "version": "1.1.7",
       "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.7.tgz",
       "integrity": "sha512-rqWnm76nYT8HoNNqEjpgJ7Pw/DrBj5iBTrmEPo6HTX5+VJyBNOqTdv4g89G63HuR5g0AaENoAcH7Is5fF2kZ8Q==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@radix-ui/react-arrow": {
       "version": "1.1.15",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-arrow/-/react-arrow-1.1.15.tgz",
       "integrity": "sha512-v4zggRcjadnI+ClKDuijlQEW4tw3NoaeHc/PwpKnLoLLKNUG4InLegkstooLcRIUWCs+8L22dGURCVuFfOKfnA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-primitive": "2.1.10"
@@ -1546,6 +1568,7 @@
       "version": "1.1.15",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-collection/-/react-collection-1.1.15.tgz",
       "integrity": "sha512-9W+B9NPF0NaaPh/1NJd3+KqsnlLqU9H7T2rvww+fp+T/evVXdNAyYcnfRQZFOjkR1ajQp3yORlqnI8soawLvNA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-compose-refs": "1.1.5",
@@ -1572,6 +1595,7 @@
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.5.tgz",
       "integrity": "sha512-+48PbAAbq3didjJxa+OaWY2ZwgAKsNiRGyeHKszblZMQ+kcpd9pAaT11cMkGEie0vsOi3QdeTE6d5Fe3Gn61kA==",
+      "dev": true,
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "*",
@@ -1587,6 +1611,7 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.2.2.tgz",
       "integrity": "sha512-RHCUGwKHDr0hDGg4X7ma4JG4/+12qxw8rkh5QKdDldlCvtja6nUx1Ef/8HVrJze81lEsgLQlqjzjGNHantgnQA==",
+      "dev": true,
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "*",
@@ -1602,6 +1627,7 @@
       "version": "1.1.23",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-dialog/-/react-dialog-1.1.23.tgz",
       "integrity": "sha512-Ksw4WeROkO4rC9k/onilX/Ao2Cr1ku1unMNH+XSCcP4jSXYu7HDsg9n4ojMjVb22XpYjAQ9qfrFlVbru1vXDUA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@radix-ui/primitive": "1.1.7",
@@ -1639,6 +1665,7 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-direction/-/react-direction-1.1.4.tgz",
       "integrity": "sha512-5pzg4FGQNpExhnhT2zlrP1wZFaYCd1K0nYWoFAdcYoYK868IEigqMX3B3f8yIoRlAhAeDWciLI6ZdCKHF9P4Vg==",
+      "dev": true,
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "*",
@@ -1654,6 +1681,7 @@
       "version": "1.1.19",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.1.19.tgz",
       "integrity": "sha512-8g4pfOL9HoKKLWGiypT+dphVqjFfmcXO5GBnhsG6zI+lxAx/8feQpr+1LSN8Re3hiZ+XkLNS4O9ztK11/LzQ6w==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@radix-ui/primitive": "1.1.7",
@@ -1681,6 +1709,7 @@
       "version": "2.1.24",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-dropdown-menu/-/react-dropdown-menu-2.1.24.tgz",
       "integrity": "sha512-geq8l2rJkxvkXsT9RMgtUE3P8pITFpTsvYpbySi1IH4fZEABD/Gp85myayFgxk0ktljGMJnCbeFkyTusvSvv7g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@radix-ui/primitive": "1.1.7",
@@ -1710,6 +1739,7 @@
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-guards/-/react-focus-guards-1.1.6.tgz",
       "integrity": "sha512-RNOJjfZMTyBM6xYmV3IVGXkPjIhcBAuv48POevAXwrGJhkWZ9p1rFoIS1JFooPuT193AZmRsCPhpoVJxx6OPoQ==",
+      "dev": true,
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "*",
@@ -1725,6 +1755,7 @@
       "version": "1.1.16",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-scope/-/react-focus-scope-1.1.16.tgz",
       "integrity": "sha512-wmRZ2WWLvmt6KHy2rNPOdPUjwq5xOHY02+m+udwJTn0aNIox/rkskAvJTyTLGhPK6KgrUjlJUJpgmx/+wFiFIQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-compose-refs": "1.1.5",
@@ -1750,6 +1781,7 @@
       "version": "1.1.23",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-hover-card/-/react-hover-card-1.1.23.tgz",
       "integrity": "sha512-H8qONfZd3ltrU3+jHCIgITbWo6e1iTKvP9DHdrvYbX48ooRM5FjEDTn16AMwdfuOGkWdZEhpl3PLL/Wk/AnHDQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@radix-ui/primitive": "1.1.7",
@@ -1781,6 +1813,7 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-id/-/react-id-1.1.4.tgz",
       "integrity": "sha512-TMQp2llA+RYn7JcjnrMnz7wN4pcVttPZnRZo52PLQsoLVKzNlVwUeHmfePgTgRluXFvlD3GD5g5MOVVTJCO0qA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-use-layout-effect": "1.1.4"
@@ -1799,6 +1832,7 @@
       "version": "2.1.24",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-menu/-/react-menu-2.1.24.tgz",
       "integrity": "sha512-uW7RVuU6Lp/ZtfeY4b3kL32zccgEWvPv1+cf17ubYzHa9cL8AHokmk36cG/XEiH/smbQvumnieXX9j/e9RqJWA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@radix-ui/primitive": "1.1.7",
@@ -1839,6 +1873,7 @@
       "version": "1.3.7",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-popper/-/react-popper-1.3.7.tgz",
       "integrity": "sha512-UsJrrd7w4wuKKTdvd/DNERVlwSlUcyXzjhyDwBk+3aPOsCjOY6ZSbxuw8E6lZTjjfP8Cpd0J8VVkrYUWyGYXyg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@floating-ui/react-dom": "^2.0.0",
@@ -1871,6 +1906,7 @@
       "version": "1.1.17",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-portal/-/react-portal-1.1.17.tgz",
       "integrity": "sha512-vKQLcWypUnwZVvfV7UkGahH2g6ySe8M8R+zYBwPrv5byZ9QAW6cQVvNKo7GgmD+p8aYb6D9JBuvy8/WhOno2wQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-primitive": "2.1.10",
@@ -1895,6 +1931,7 @@
       "version": "1.1.10",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.1.10.tgz",
       "integrity": "sha512-3wyzCQ6+ubRA+D4uv9m95JYLXxmOHp05qjrkjeA7uKHHtjpPggQzc6DAb0URl7j67oR0K2foO4ip27TiX037Bw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-use-layout-effect": "1.1.4"
@@ -1918,6 +1955,7 @@
       "version": "2.1.10",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.10.tgz",
       "integrity": "sha512-MucOnzh6hR5mid6VpkbglRAMYMjKLqRnGBbjXkzjK52fuQDd1qbkx78a5P40mkcnVXJdEVxm26E9OPAiUq7nBg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-slot": "1.3.3"
@@ -1941,6 +1979,7 @@
       "version": "1.1.19",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-roving-focus/-/react-roving-focus-1.1.19.tgz",
       "integrity": "sha512-V9jI6hDjT7l3jsCQD9bLNvDLM3tH/gdbOTp7Tefp3hbbgCGQoK7tUvrWiRlcoBHIZ809ElXwNQwVo0B98LuTXQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@radix-ui/primitive": "1.1.7",
@@ -1974,6 +2013,7 @@
       "version": "1.2.18",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-scroll-area/-/react-scroll-area-1.2.18.tgz",
       "integrity": "sha512-Zn5Cd171wxsO3Dfg8HaW6RifTb9CYTKQJHs/G4+LN1GfmJpaQMZQyQxMprVPHpaz7QY4l9BxK2JwQuzHsXC8nA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@radix-ui/number": "1.1.3",
@@ -2005,6 +2045,7 @@
       "version": "1.1.15",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-separator/-/react-separator-1.1.15.tgz",
       "integrity": "sha512-jOLO4lssEzWpoDu7G+Ze4VjwMRUBt291pnZD0gmalREZipnTX3wadQo7Fy48GCTfe14/YRN6rw/rOJqrE85Wxw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-primitive": "2.1.10"
@@ -2028,6 +2069,7 @@
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.3.3.tgz",
       "integrity": "sha512-qx7oqnYbxnK9kYI9m317qmFmEgo6ywqWvbTogdj7cL9p3/yx4M48p7Rnw5z3H890cL/ow/EeWJsuTykeZVXP5Q==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-compose-refs": "1.1.5"
@@ -2046,6 +2088,7 @@
       "version": "1.2.16",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-tooltip/-/react-tooltip-1.2.16.tgz",
       "integrity": "sha512-6EamKFRRnlpdadndbZ6LMwycfwkwPte1B42hs6QA0gYhjaOKqW4PZ4pjaW9UrlDX5eVt/OjncE7BFTPL5nmZhg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@radix-ui/primitive": "1.1.7",
@@ -2081,6 +2124,7 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.1.4.tgz",
       "integrity": "sha512-R6OUY2e2fA6Yn6s+VSx5KBV6Nx8LQEhu+cz7LCej18rQ1HLyg9PSC9jP/ZNx0o6FAIK9c0F1kHylzSxKsdlkrQ==",
+      "dev": true,
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "*",
@@ -2096,6 +2140,7 @@
       "version": "1.2.6",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.2.6.tgz",
       "integrity": "sha512-uEQJGT97ZA/TgP/Hydw47lHu+/vQj6z/0jA+WeTbK1o9Rx45GImjpD0tc3W5ad3D6XTSR6e1yEO0FvGq6WQfVQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@radix-ui/primitive": "1.1.7",
@@ -2116,6 +2161,7 @@
       "version": "0.0.5",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-use-effect-event/-/react-use-effect-event-0.0.5.tgz",
       "integrity": "sha512-7cshFL8HGS/7HEiHH+9kL9HBwp2sa9yX18Knwek6KYWmXwM7pegMgta2AXMQKI+rq3JnfSj9x8wYqFMTdG1Jgg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-use-layout-effect": "1.1.4"
@@ -2134,6 +2180,7 @@
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-use-is-hydrated/-/react-use-is-hydrated-0.1.3.tgz",
       "integrity": "sha512-umO/aJ+82CpOnhDZUTbILCQf7kU/g0iv+oGs/Q8jw7IkhWBzaEP4sA268PhFAJTFetbwp3ICc6ktpI4TqtxcIw==",
+      "dev": true,
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "*",
@@ -2149,6 +2196,7 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.4.tgz",
       "integrity": "sha512-K20DkRkUwDnxEYMBPcg3Y6voLkEy5p5QQmszZgLngKKiC7dzBR/aEuK3w1qlx2JWDUNH6FluahYdgR3BP+QbYw==",
+      "dev": true,
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "*",
@@ -2164,6 +2212,7 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-use-rect/-/react-use-rect-1.1.4.tgz",
       "integrity": "sha512-cSOCh6JlkmfjLyNcLiu2nB4v+nm+dkZ+Q5KHWk/soo4U7ZLiEQFKHK9/YmtBHjfCEaU43IBKQOc4/uJmCaiCTQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@radix-ui/rect": "1.1.3"
@@ -2182,6 +2231,7 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-use-size/-/react-use-size-1.1.4.tgz",
       "integrity": "sha512-D3anSY15EJoxrihpsXI6SMrmmonnQtR2ni7arO+Lfdg3O95b9hNXxONk8jA5C8ANdF/h5HMAxejgs8PWJ6rlhw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-use-layout-effect": "1.1.4"
@@ -2200,6 +2250,7 @@
       "version": "1.2.11",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-visually-hidden/-/react-visually-hidden-1.2.11.tgz",
       "integrity": "sha512-NFS86RYYZb4/exihaESBGOpMJFz8MGLAfu3mOBSGByVnVPC9JPASfYubxd/8KbkQK0sYAv8lVQDEQukDX/qXvQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-primitive": "2.1.10"
@@ -2223,6 +2274,7 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/@radix-ui/rect/-/rect-1.1.3.tgz",
       "integrity": "sha512-JtyZR+mqgBibTo8xea3B6ZRmzZiM/YeVBtUkas6zMuXjAlfIFIW2FgqeM9eLyvEaYX66vr6DJMK+4U6LV0KhNw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@rolldown/binding-android-arm64": {
@@ -2868,6 +2920,7 @@
       "version": "5.101.4",
       "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.101.4.tgz",
       "integrity": "sha512-gNwcvOJcRbLWPOLG/2OBm+zM+Yv+MKsXKEOWC57USuZDEsI71hEErQsiEGx5wX9rzWWkfwM0fVSPoiIFSsxfiw==",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -2878,6 +2931,7 @@
       "version": "5.101.4",
       "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.101.4.tgz",
       "integrity": "sha512-yRg2pfOCxIs4ZJW3XYYHU/WgtD04FHSnfHlpRT7h7pR77hwkdRG4wxbKe4aq6P0RvXUTBSQpQeadS1SUYUe+KA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@tanstack/query-core": "5.101.4"
@@ -3091,7 +3145,7 @@
       "version": "19.2.17",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.17.tgz",
       "integrity": "sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -3101,7 +3155,7 @@
       "version": "19.2.3",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.2.0"
@@ -3585,6 +3639,7 @@
       "version": "1.2.6",
       "resolved": "https://registry.npmjs.org/aria-hidden/-/aria-hidden-1.2.6.tgz",
       "integrity": "sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.0.0"
@@ -3751,6 +3806,7 @@
       "version": "0.7.1",
       "resolved": "https://registry.npmjs.org/class-variance-authority/-/class-variance-authority-0.7.1.tgz",
       "integrity": "sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "clsx": "^2.1.1"
@@ -3832,6 +3888,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
       "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -3863,6 +3920,16 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/commander": {
+      "version": "9.5.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-9.5.0.tgz",
+      "integrity": "sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || >=14"
+      }
     },
     "node_modules/concurrently": {
       "version": "10.0.4",
@@ -3907,6 +3974,7 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/crelt/-/crelt-1.0.6.tgz",
       "integrity": "sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/cross-spawn": {
@@ -3948,7 +4016,7 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/data-urls": {
@@ -4031,6 +4099,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/detect-node-es/-/detect-node-es-1.1.0.tgz",
       "integrity": "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/diff": {
@@ -5217,6 +5286,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/get-nonce/-/get-nonce-1.0.1.tgz",
       "integrity": "sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -5875,6 +5945,7 @@
       "version": "1.28.0",
       "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-1.28.0.tgz",
       "integrity": "sha512-fARAFJULsGuDDydjp6+6blekG/sBIM29TerzLjc9bQUKAcEfrSc4ZQKb25KRz4OMKd87cZTb5dgq0w/T6KufVg==",
+      "dev": true,
       "license": "ISC",
       "peerDependencies": {
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
@@ -6157,6 +6228,22 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/postject": {
+      "version": "1.0.0-alpha.6",
+      "resolved": "https://registry.npmjs.org/postject/-/postject-1.0.0-alpha.6.tgz",
+      "integrity": "sha512-b9Eb8h2eVqNE8edvKdwqkrY6O7kAwmI8kcnBv1NScolYJbo59XUF0noFq+lxbC1yN20bmC0WBEbDC5H/7ASb0A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "commander": "^9.4.0"
+      },
+      "bin": {
+        "postject": "dist/cli.js"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -6356,6 +6443,7 @@
       "version": "19.2.8",
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.8.tgz",
       "integrity": "sha512-PWaYA1L/q9u2u7xYQi+Y3L3Yfnie7XyLeaJICV1MGD6LprsBxcAqGjYyr0eY3p+QdsA+x/Irkt4Qif8D63+Sbw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -6365,6 +6453,7 @@
       "version": "19.2.8",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.8.tgz",
       "integrity": "sha512-rVprimfGBG3DR+Tq0IQG2DT5PxKth1WIGDmj5yPmlzr4YBe7uyE+Du4oVqTDXZSHGGGXRtTJEGSSePyQCMBglQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "scheduler": "^0.27.0"
@@ -6385,6 +6474,7 @@
       "version": "2.7.2",
       "resolved": "https://registry.npmjs.org/react-remove-scroll/-/react-remove-scroll-2.7.2.tgz",
       "integrity": "sha512-Iqb9NjCCTt6Hf+vOdNIZGdTiH1QSqr27H/Ek9sv/a97gfueI/5h1s3yRi1nngzMUaOOToin5dI1dXKdXiF+u0Q==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "react-remove-scroll-bar": "^2.3.7",
@@ -6410,6 +6500,7 @@
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/react-remove-scroll-bar/-/react-remove-scroll-bar-2.3.8.tgz",
       "integrity": "sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "react-style-singleton": "^2.2.2",
@@ -6432,6 +6523,7 @@
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/react-style-singleton/-/react-style-singleton-2.2.3.tgz",
       "integrity": "sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "get-nonce": "^1.0.0",
@@ -6454,6 +6546,7 @@
       "version": "4.18.11",
       "resolved": "https://registry.npmjs.org/react-virtuoso/-/react-virtuoso-4.18.11.tgz",
       "integrity": "sha512-Qeeq9vqa5seCxACvzbQTUeq3s2/Bu+VlwOMF0jfy3E/ZKHLiXWwJpXBhv2rckqYkvm1XRVFLCBMCmqCU8JNEJg==",
+      "dev": true,
       "license": "MIT",
       "peerDependencies": {
         "react": ">=16 || >=17 || >= 18 || >= 19",
@@ -6572,6 +6665,7 @@
       "version": "0.27.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
       "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/semver": {
@@ -6701,6 +6795,7 @@
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/style-mod/-/style-mod-4.1.3.tgz",
       "integrity": "sha512-i/n8VsZydrugj3Iuzll8+x/00GH2vnYsk1eomD8QiRrSAeW6ItbCQDtfXCeJHd0iwiNagqjQkvpvREEPtW3IoQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/supports-color": {
@@ -6727,6 +6822,7 @@
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-3.6.0.tgz",
       "integrity": "sha512-uxL7qAVQriqRQPAyK3pj66VqskWqoZ37PW94jwOTwNfq/z9oyu1V+eqrZqtR2+fCiXdYOZe/Modt8GtvqNzu+w==",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -6926,6 +7022,7 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
       "license": "0BSD"
     },
     "node_modules/tsx": {
@@ -7060,6 +7157,7 @@
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/use-callback-ref/-/use-callback-ref-1.3.3.tgz",
       "integrity": "sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.0.0"
@@ -7081,6 +7179,7 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/use-sidecar/-/use-sidecar-1.1.3.tgz",
       "integrity": "sha512-Fedw0aZvkhynoPYlA5WXrMCAMm+nSWdZt6lzJQ7Ok8S6Q+VsHmHpRWndVRJ8Be0ZbkfPc5LRYH+5XrzXcEeLRQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "detect-node-es": "^1.1.0",
@@ -7278,6 +7377,7 @@
       "version": "2.2.8",
       "resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.8.tgz",
       "integrity": "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/w3c-xmlserializer": {

--- a/package.json
+++ b/package.json
@@ -145,6 +145,7 @@
     "globals": "^17.8.0",
     "jsdom": "^30.0.0",
     "lucide-react": "^1.27.0",
+    "postject": "1.0.0-alpha.6",
     "qrcode": "^1.5.4",
     "react": "^19.2.8",
     "react-dom": "^19.2.8",

--- a/scripts/build-binary.mjs
+++ b/scripts/build-binary.mjs
@@ -130,6 +130,31 @@ function clientAssets() {
 
 
 /**
+ * GNU tar, which is not what `tar` means on macOS.
+ *
+ * The reproducible flags below — `--sort`, `--mtime`, the pax options — are GNU
+ * extensions, and macOS ships bsdtar, which rejects them outright. `gtar` is
+ * the conventional name for GNU tar where both exist. Checked rather than
+ * assumed, because the failure is otherwise a wall of tar usage text in the
+ * middle of a build that has already taken minutes.
+ */
+function gnuTar() {
+  for (const candidate of ['gtar', 'tar']) {
+    try {
+      if (/GNU tar/.test(run(candidate, ['--version']))) return candidate
+    } catch {
+      continue
+    }
+  }
+
+  return fail(
+    'GNU tar is required to build a reproducible archive.',
+    'macOS ships bsdtar, which does not accept --sort or --mtime.',
+    'On macOS: brew install gnu-tar',
+  )
+}
+
+/**
  * The licences we are obliged to redistribute alongside the binary.
  *
  * This executable *contains* a Node runtime, so shipping it means
@@ -199,7 +224,7 @@ async function writeArchive(binary) {
       stdio: ['ignore', 'pipe', 'inherit'],
     })
   } else {
-    run('tar', [
+    run(gnuTar(), [
       '--sort=name',
       `--mtime=@${FIXED_MTIME}`,
       '--owner=0', '--group=0', '--numeric-owner',

--- a/scripts/build-binary.mjs
+++ b/scripts/build-binary.mjs
@@ -184,10 +184,16 @@ async function writeArchive(binary) {
   rmSync(out, { force: true })
 
   if (process.platform === 'win32') {
-    // Entries sorted and listed rather than walked, `-X` to drop uid/gid and
-    // the extra timestamp fields, `TZ=UTC` because ZIP stores DOS local time.
+    // Relative paths, resolved against `cwd`. Absolute ones make 7z store bare
+    // file names, which flattens the archive: the smoke test then finds no
+    // directory to enter, and WinGet's `RelativeFilePath` — which names
+    // `<dir>\\looptroop.exe` — points at nothing.
+    //
+    // `-mtc=off -mta=off` so creation and access times stay out; the modified
+    // time is already fixed, and `TZ=UTC` keeps ZIP's DOS local time stable
+    // wherever this runs.
     const entries = readdirSync(staging).sort().map((entry) => `${name}/${entry}`)
-    execFileSync('7z', ['a', '-tzip', '-mx=9', out, ...entries.map((e) => join(stagingRoot, e))], {
+    execFileSync('7z', ['a', '-tzip', '-mx=9', '-mtc=off', '-mta=off', out, ...entries], {
       cwd: stagingRoot,
       env: { ...process.env, TZ: 'UTC' },
       stdio: ['ignore', 'pipe', 'inherit'],

--- a/scripts/build-binary.mjs
+++ b/scripts/build-binary.mjs
@@ -37,11 +37,14 @@
 import { build } from 'esbuild'
 import { execFileSync } from 'node:child_process'
 import { createHash } from 'node:crypto'
-import { chmodSync, copyFileSync, existsSync, mkdirSync, readdirSync, readFileSync, rmSync, statSync, writeFileSync } from 'node:fs'
-import { dirname, join, relative, resolve } from 'node:path'
+import { chmodSync, copyFileSync, existsSync, mkdirSync, readdirSync, readFileSync, rmSync, utimesSync, writeFileSync } from 'node:fs'
+import { basename, dirname, join, relative, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
 const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..')
+
+/** 1980-01-01, the same fixed timestamp the bundle archives use. */
+const FIXED_MTIME = 315_532_800
 
 function fail(message, ...detail) {
   process.stderr.write(`\nFAIL: ${message}\n`)
@@ -123,6 +126,87 @@ function clientAssets() {
 
   walk(clientDir)
   return assets
+}
+
+
+/**
+ * The licences we are obliged to redistribute alongside the binary.
+ *
+ * This executable *contains* a Node runtime, so shipping it means
+ * redistributing Node, and Node's licence — which carries the notices of
+ * everything Node itself bundles, OpenSSL and ICU among them — has to travel
+ * with it. Fetched for the exact version embedded rather than vendored, so it
+ * can never describe a different runtime from the one inside.
+ *
+ * Failing loudly if it cannot be fetched is deliberate. An archive that
+ * silently omits it is the one outcome that is not acceptable.
+ */
+async function nodeLicense() {
+  const url = `https://raw.githubusercontent.com/nodejs/node/${process.version}/LICENSE`
+  const response = await fetch(url)
+  if (!response.ok) {
+    fail(
+      `Cannot fetch the licence for the Node runtime being embedded (${process.version}).`,
+      `${response.status} from ${url}`,
+      'The archive must carry it: shipping this binary redistributes Node.',
+    )
+  }
+  return response.text()
+}
+
+/**
+ * The binary, its licences, and nothing else, in the format each platform's
+ * tooling expects: `.zip` on Windows because that is what WinGet reads and what
+ * Windows unpacks natively, `.tar.gz` elsewhere.
+ *
+ * Reproducible by the same rules as the bundle archives, and for the same
+ * reason — a manifest records this hash.
+ */
+async function writeArchive(binary) {
+  const staging = join(work, 'archive', `looptroop-${version}-${OS_TAG}-${ARCH_TAG}`)
+  mkdirSync(staging, { recursive: true })
+
+  copyFileSync(binary, join(staging, `looptroop${exeSuffix}`))
+  chmodSync(join(staging, `looptroop${exeSuffix}`), 0o755)
+  for (const file of ['LICENSE', 'README.md', 'THIRD-PARTY-NOTICES.md']) {
+    copyFileSync(join(repoRoot, file), join(staging, file))
+  }
+  writeFileSync(join(staging, 'LICENSE.node.txt'), await nodeLicense())
+
+  for (const entry of readdirSync(staging)) {
+    utimesSync(join(staging, entry), FIXED_MTIME, FIXED_MTIME)
+  }
+  utimesSync(staging, FIXED_MTIME, FIXED_MTIME)
+
+  const stagingRoot = dirname(staging)
+  const name = basename(staging)
+  const out = join(outDir, `${name}${process.platform === 'win32' ? '.zip' : '.tar.gz'}`)
+  rmSync(out, { force: true })
+
+  if (process.platform === 'win32') {
+    // Entries sorted and listed rather than walked, `-X` to drop uid/gid and
+    // the extra timestamp fields, `TZ=UTC` because ZIP stores DOS local time.
+    const entries = readdirSync(staging).sort().map((entry) => `${name}/${entry}`)
+    execFileSync('7z', ['a', '-tzip', '-mx=9', out, ...entries.map((e) => join(stagingRoot, e))], {
+      cwd: stagingRoot,
+      env: { ...process.env, TZ: 'UTC' },
+      stdio: ['ignore', 'pipe', 'inherit'],
+    })
+  } else {
+    run('tar', [
+      '--sort=name',
+      `--mtime=@${FIXED_MTIME}`,
+      '--owner=0', '--group=0', '--numeric-owner',
+      '--format=pax',
+      '--pax-option=exthdr.name=%d/PaxHeaders/%f,delete=atime,delete=ctime',
+      '--use-compress-program=gzip -9 -n',
+      '-cf', out,
+      '-C', stagingRoot,
+      name,
+    ], { cwd: repoRoot })
+  }
+
+  return out
 }
 
 try {
@@ -207,6 +291,10 @@ try {
   const bytes = readFileSync(binaryPath)
   const sha256 = createHash('sha256').update(bytes).digest('hex')
 
+  const archivePath = await writeArchive(binaryPath)
+  const archiveBytes = readFileSync(archivePath)
+  const archiveSha = createHash('sha256').update(archiveBytes).digest('hex')
+
   process.stdout.write([
     '',
     `binary      ${binaryName}`,
@@ -214,7 +302,11 @@ try {
     `interface   ${Object.keys(assets).length} files`,
     `bytes       ${bytes.length}`,
     `sha256      ${sha256}`,
-    `wrote       ${binaryPath}`,
+    '',
+    `archive     ${basename(archivePath)}`,
+    `bytes       ${archiveBytes.length}`,
+    `sha256      ${archiveSha}`,
+    `wrote       ${archivePath}`,
     '',
   ].join('\n'))
 } finally {

--- a/scripts/build-binary.mjs
+++ b/scripts/build-binary.mjs
@@ -1,0 +1,222 @@
+#!/usr/bin/env node
+/**
+ * Builds the standalone executable: LoopTroop with a Node runtime inside it.
+ *
+ *   node scripts/build-binary.mjs --out dist-binary
+ *
+ * The point is a LoopTroop that runs on a machine with no Node at all. Homebrew,
+ * Scoop and Chocolatey install Node for the user; WinGet's portable installer
+ * refuses anything but an `.exe`, and `ubi` and `eget` fetch a binary or
+ * nothing. This is what serves those.
+ *
+ * ## Why the two-step flow and not `--build-sea`
+ *
+ * `node --build-sea` is one command and arrived in Node 25.5. This project
+ * pins 24.15.0 everywhere, and 24 has only `--experimental-sea-config` plus
+ * `postject`. Building on a newer Node would embed a runtime the test matrix
+ * never exercises, which contradicts the floor being a promise on all three
+ * platforms — and Node 25 is EOL besides. Revisit at the Node 26 LTS bump,
+ * which is already on the floor-bump checklist.
+ *
+ * A hard constraint follows: the Node that produces the blob must be the same
+ * version as the Node it is injected into, so this copies the running
+ * executable rather than downloading one.
+ *
+ * ## Why CommonJS
+ *
+ * Node 24's SEA runs a CommonJS script and has no `mainFormat`. The entry is
+ * therefore bundled as CJS — one esbuild flag, and the package already ships a
+ * `.cjs` launcher, so nothing about that is new.
+ *
+ * `import.meta` does not exist in CommonJS output, and six modules read
+ * `import.meta.url` — one of them at the top level, where the failure would be
+ * a crash before any command runs. The banner below defines it from
+ * `__filename`, which is what esbuild's own documentation recommends and what
+ * makes those six compile unchanged.
+ */
+import { build } from 'esbuild'
+import { execFileSync } from 'node:child_process'
+import { createHash } from 'node:crypto'
+import { chmodSync, copyFileSync, existsSync, mkdirSync, readdirSync, readFileSync, rmSync, statSync, writeFileSync } from 'node:fs'
+import { dirname, join, relative, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..')
+
+function fail(message, ...detail) {
+  process.stderr.write(`\nFAIL: ${message}\n`)
+  for (const line of detail) process.stderr.write(`  ${line}\n`)
+  process.stderr.write('\n')
+  process.exit(1)
+}
+
+function run(command, args, options = {}) {
+  return execFileSync(command, args, { encoding: 'utf8', stdio: ['ignore', 'pipe', 'inherit'], ...options })
+}
+
+const args = process.argv.slice(2)
+const outIndex = args.indexOf('--out')
+const outDir = resolve(outIndex === -1 ? join(repoRoot, 'dist-binary') : args[outIndex + 1] ?? fail('--out needs a path'))
+
+const pkg = JSON.parse(readFileSync(join(repoRoot, 'package.json'), 'utf8'))
+const version = pkg.version
+
+/**
+ * The platform tag in the file name. `process.platform` and `process.arch` name
+ * the machine this runs on, which is the only machine it can build for: a SEA
+ * embeds the running Node, and a cross-built one would have to disable the code
+ * cache and still carry the wrong runtime. Each target is built on its own
+ * runner instead.
+ */
+const OS_TAG = { linux: 'linux', darwin: 'darwin', win32: 'win' }[process.platform]
+  ?? fail(`No binary target for ${process.platform}.`)
+const ARCH_TAG = { x64: 'x64', arm64: 'arm64' }[process.arch]
+  ?? fail(`No binary target for ${process.arch}.`)
+
+// macOS x64 is not a supported SEA target — the Node documentation says arm64
+// only, and that x64 "is not currently supported and is skipped in the tests".
+// Intel Macs keep Homebrew and npm, which work.
+if (process.platform === 'darwin' && process.arch === 'x64') {
+  fail(
+    'Node does not support single-executable applications on macOS x64.',
+    'Intel Macs install through Homebrew or npm instead.',
+  )
+}
+
+const exeSuffix = process.platform === 'win32' ? '.exe' : ''
+const binaryName = `looptroop-${version}-${OS_TAG}-${ARCH_TAG}${exeSuffix}`
+const binaryPath = join(outDir, binaryName)
+
+if (!existsSync(join(repoRoot, 'dist', 'server', 'cli', 'cli.js'))) {
+  fail('dist/ is missing or incomplete.', 'Run `npm run build` first.')
+}
+
+const clientDir = join(repoRoot, 'dist', 'client')
+if (!existsSync(join(clientDir, 'index.html'))) {
+  fail('dist/client is missing.', 'The interface travels inside the executable; run `npm run build` first.')
+}
+
+/**
+ * A fixed staging path, not a temporary one.
+ *
+ * The SEA blob embeds the absolute path of the script it was built from, so a
+ * `mkdtemp` directory makes every build produce different bytes — proved by
+ * building twice and comparing. Inside `node_modules` because that is already
+ * ignored by git and by every packaging gate.
+ */
+const work = join(repoRoot, 'node_modules', '.cache', 'looptroop-binary')
+rmSync(work, { recursive: true, force: true })
+mkdirSync(work, { recursive: true })
+
+/** Every built client file, keyed the way `seaAssets.ts` looks them up. */
+function clientAssets() {
+  const assets = {}
+
+  const walk = (dir) => {
+    for (const entry of readdirSync(dir, { withFileTypes: true }).sort((a, b) => a.name.localeCompare(b.name))) {
+      const full = join(dir, entry.name)
+      if (entry.isDirectory()) walk(full)
+      // Forward slashes on every platform: the key is a lookup string, not a path.
+      else assets[`client/${relative(clientDir, full).split('\\').join('/')}`] = full
+    }
+  }
+
+  walk(clientDir)
+  return assets
+}
+
+try {
+  process.stdout.write('Bundling the entry point...\n')
+  const entry = join(work, 'entry.cjs')
+
+  await build({
+    entryPoints: [join(repoRoot, 'server', 'cli', 'cli.ts')],
+    outfile: entry,
+    bundle: true,
+    platform: 'node',
+    format: 'cjs',
+    target: 'node24',
+    // Nothing external: there is no `node_modules` beside a single file.
+    define: {
+      __LOOPTROOP_VERSION__: JSON.stringify(version),
+      // CommonJS has no `import.meta`; the banner supplies one from
+      // `__filename`, which is what makes the six modules that read it compile
+      // unchanged.
+      'import.meta.url': '__LOOPTROOP_META_URL__',
+    },
+    banner: { js: 'const __LOOPTROOP_META_URL__ = require("node:url").pathToFileURL(__filename).href;' },
+    // An `import.meta` esbuild could not rewrite would be an empty object at
+    // runtime, so it must never be a warning that scrolls past.
+    logOverride: { 'empty-import-meta': 'error' },
+    logLevel: 'warning',
+  })
+
+  const bundled = readFileSync(entry, 'utf8')
+  if (/\bimport\.meta\b/.test(bundled)) {
+    fail('The bundle still contains `import.meta`, which is an empty object in CommonJS.')
+  }
+
+  const assets = clientAssets()
+  process.stdout.write(`Embedding ${Object.keys(assets).length} interface files...\n`)
+
+  writeFileSync(join(work, 'sea-config.json'), `${JSON.stringify({
+    main: entry,
+    output: join(work, 'sea-prep.blob'),
+    disableExperimentalSEAWarning: true,
+    // `import()` does not work with the code cache, and every CLI command is a
+    // lazy import. Snapshots are incompatible with the rest of this anyway.
+    useCodeCache: false,
+    useSnapshot: false,
+    assets,
+  }, null, 2)}\n`)
+
+  process.stdout.write('Preparing the blob...\n')
+  run(process.execPath, ['--experimental-sea-config', join(work, 'sea-config.json')], { cwd: work })
+
+  mkdirSync(outDir, { recursive: true })
+  rmSync(binaryPath, { force: true })
+  copyFileSync(process.execPath, binaryPath)
+  chmodSync(binaryPath, 0o755)
+
+  // macOS and Windows binaries are signed, and postject cannot rewrite a signed
+  // one. Removing it first is a required step of the documented flow, not a
+  // tidy-up: skip it and injection fails, or produces something that will not
+  // run.
+  if (process.platform === 'darwin') {
+    run('codesign', ['--remove-signature', binaryPath])
+  }
+
+  process.stdout.write('Injecting...\n')
+  run(process.execPath, [
+    join(repoRoot, 'node_modules', 'postject', 'dist', 'cli.js'),
+    binaryPath,
+    'NODE_SEA_BLOB',
+    join(work, 'sea-prep.blob'),
+    '--sentinel-fuse', 'NODE_SEA_FUSE_fce680ab2cc467b6e072b8b5df1996b2',
+    // The Mach-O segment the blob lives in. Only macOS needs it, and injection
+    // fails without it there.
+    ...(process.platform === 'darwin' ? ['--macho-segment-name', 'NODE_SEA'] : []),
+  ], { cwd: repoRoot })
+
+  // Ad-hoc, which is free and is not notarization. Without it an arm64 binary
+  // will not execute at all: macOS refuses an unsigned one outright.
+  if (process.platform === 'darwin') {
+    run('codesign', ['--sign', '-', binaryPath])
+  }
+
+  const bytes = readFileSync(binaryPath)
+  const sha256 = createHash('sha256').update(bytes).digest('hex')
+
+  process.stdout.write([
+    '',
+    `binary      ${binaryName}`,
+    `runtime     ${process.version} (embedded)`,
+    `interface   ${Object.keys(assets).length} files`,
+    `bytes       ${bytes.length}`,
+    `sha256      ${sha256}`,
+    `wrote       ${binaryPath}`,
+    '',
+  ].join('\n'))
+} finally {
+  rmSync(work, { recursive: true, force: true })
+}

--- a/scripts/build-server.mjs
+++ b/scripts/build-server.mjs
@@ -32,9 +32,13 @@ const result = await build({
   minify: false,
   metafile: true,
   logLevel: 'info',
-  // package.json is read at runtime for the version; keep it resolvable.
   define: {
     'process.env.LOOPTROOP_BUILD': JSON.stringify('production'),
+    // Compiled in rather than read off disk at runtime. Two callers used to
+    // resolve `package.json` relative to their own module, which holds for an
+    // npm install and nowhere else — most importantly in a single-file build,
+    // where there is no `package.json` and the answer was a silent `0.0.0`.
+    __LOOPTROOP_VERSION__: JSON.stringify(pkg.version),
   },
 })
 

--- a/scripts/channel-inputs.ts
+++ b/scripts/channel-inputs.ts
@@ -61,6 +61,13 @@ if (bundle === undefined) {
 // repaired for those versions, and only the WinGet job needs to refuse.
 const zip = Object.keys(assets).find((name) => name.endsWith('-bundle.zip')) ?? null
 
+// The standalone Windows binary, which is what WinGet installs — its portable
+// installer accepts an `.exe` and nothing else, so it cannot take the bundle
+// the other three channels use. Absent from releases published before the
+// binaries existed, and reported as empty rather than fatal for the same
+// reason the bundle zip is.
+const winBinary = Object.keys(assets).find((name) => /-win-x64\.zip$/.test(name)) ?? null
+
 const output = {
   version: manifest.version,
   bundle,
@@ -69,6 +76,9 @@ const output = {
   zip: zip ?? '',
   zip_sha256: zip === null ? '' : assets[zip]!.sha256,
   zip_url: zip === null ? '' : `https://github.com/${repo}/releases/download/v${manifest.version}/${zip}`,
+  win_binary: winBinary ?? '',
+  win_binary_sha256: winBinary === null ? '' : assets[winBinary]!.sha256,
+  win_binary_url: winBinary === null ? '' : `https://github.com/${repo}/releases/download/v${manifest.version}/${winBinary}`,
   // The commit this release was built from, so a repair can render descriptors
   // with that release's templates rather than whatever the default branch says
   // today. Empty when the manifest predates the field or the release was built

--- a/scripts/package-manifests.ts
+++ b/scripts/package-manifests.ts
@@ -201,6 +201,11 @@ export function bundleZipFileName(version: string): string {
   return `looptroop-${version}-bundle.zip`
 }
 
+/** The standalone Windows binary's archive, which is what WinGet installs. */
+export function windowsBinaryZipName(version: string): string {
+  return `looptroop-${version}-win-x64.zip`
+}
+
 /**
  * Publisher and package, joined, as WinGet identifies a package everywhere.
  *
@@ -233,18 +238,22 @@ export function wingetManifestDir(version: string): string {
  *
  * Two decisions worth naming.
  *
- * `InstallerType: zip` with `NestedInstallerType: portable` is the only shape
- * that fits us: the bundle is an archive containing a launcher, not an
- * installer. `PortableCommandAlias` is what actually puts `looptroop` on the
- * user's PATH, and `RelativeFilePath` points at the `.cmd` wrapper rather than
- * the `#!` script, for the same reason Scoop's `bin` does — a shebang is not
- * executable on Windows.
+ * It installs the **standalone binary**, not the bundle every other channel
+ * takes. That is not a preference: `winget validate` refuses a portable whose
+ * `RelativeFilePath` is anything but an `.exe`, and rejected the bundle's
+ * `.cmd` shim outright —
  *
- * And the dependencies are declared rather than assumed. WinGet installs
- * `PackageDependencies` by default — `skipDependencies` defaults to false —
- * which is what lets this channel ship the ordinary bundle instead of waiting
- * for a standalone binary. A user who has turned that off gets a package that
- * needs a Node they may not have, which is why `doctor` still checks.
+ *   Manifest Error: The file type of the referenced file is not allowed.
+ *   [RelativeFilePath] Value: looptroop\\bin\\looptroop.cmd
+ *
+ * The winget *client* does run `.cmd` portables; the repository's validation
+ * pipeline does not accept them. `PortableCommandAlias` is what puts
+ * `looptroop` on the user's PATH.
+ *
+ * And it declares only git. The binary carries its own Node runtime, so
+ * unlike the Homebrew, Scoop and Chocolatey packages there is nothing to
+ * install for it — but `doctor` still treats git as required and Windows does
+ * not ship one.
  */
 export function renderWingetManifests(inputs: ChannelInputs): Record<string, string> {
   assertInputs(inputs)
@@ -264,11 +273,10 @@ ManifestVersion: ${WINGET_MANIFEST_VERSION}
 InstallerType: zip
 NestedInstallerType: portable
 NestedInstallerFiles:
-  - RelativeFilePath: ${BUNDLE_ROOT}\\bin\\looptroop.cmd
+  - RelativeFilePath: looptroop-${inputs.version}-win-x64\\looptroop.exe
     PortableCommandAlias: looptroop
 Dependencies:
   PackageDependencies:
-    - PackageIdentifier: OpenJS.NodeJS
     - PackageIdentifier: Git.Git
 Installers:
   - Architecture: neutral

--- a/scripts/smoke-binary.mjs
+++ b/scripts/smoke-binary.mjs
@@ -94,8 +94,8 @@ const archive = resolve(flag('archive'))
 if (!existsSync(archive)) fail(`No archive at ${archive}.`)
 
 // Anchored on the platform tag rather than stopping at the first hyphen: a
-// prerelease version contains hyphens too, and a loose pattern reads
-// `0.5.1-linux` out of `looptroop-0.5.1-linux-x64`.
+// prerelease version contains hyphens too, so a loose pattern reads the
+// platform into the version and reports a mismatch that is not one.
 const version = /^looptroop-(.+)-(?:linux|darwin|win)-(?:x64|arm64)\./.exec(basename(archive))?.[1]
   ?? fail(`Cannot read a version out of ${basename(archive)}.`)
 

--- a/scripts/smoke-binary.mjs
+++ b/scripts/smoke-binary.mjs
@@ -1,0 +1,180 @@
+#!/usr/bin/env node
+/**
+ * Unpacks the standalone archive and drives it on a machine pretending to have
+ * no Node.
+ *
+ *   node scripts/smoke-binary.mjs --archive dist-binary/looptroop-9.9.9-linux-x64.tar.gz
+ *
+ * The whole claim of this artefact is that it needs nothing installed, and
+ * every GitHub runner has Node — so a binary that quietly shelled out to one
+ * would pass a naive test and fail for the user it exists for. Node is removed
+ * from PATH here, which is the only way the claim gets tested at all.
+ *
+ * The interface is checked properly rather than by fetching one page. A single-
+ * file build carries the client inside it, and a build that embedded the
+ * document but not its hashed assets serves a 200 for `/` and a blank screen to
+ * a human — so every asset the document references is fetched too.
+ */
+import { spawn, execFileSync } from 'node:child_process'
+import { existsSync, mkdirSync, mkdtempSync, readdirSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { basename, join, resolve } from 'node:path'
+
+function fail(message, ...detail) {
+  process.stderr.write(`\nFAIL: ${message}\n`)
+  for (const line of detail) process.stderr.write(`  ${line}\n`)
+  process.stderr.write('\n')
+  process.exit(1)
+}
+
+function log(message) {
+  process.stdout.write(`${message}\n`)
+}
+
+function flag(name) {
+  const index = process.argv.indexOf(`--${name}`)
+  const value = index === -1 ? undefined : process.argv[index + 1]
+  if (value === undefined || value.startsWith('--')) fail(`--${name} is required.`)
+  return value
+}
+
+const IS_WINDOWS = process.platform === 'win32'
+
+/** Always async: a synchronous child would block the checks that follow it. */
+function invoke(command, args, options = {}) {
+  return new Promise((settle, reject) => {
+    const child = spawn(command, args, { env: { ...process.env, ...options.env } })
+    let stdout = ''
+    let stderr = ''
+    child.stdout.on('data', (chunk) => { stdout += chunk.toString() })
+    child.stderr.on('data', (chunk) => { stderr += chunk.toString() })
+    child.on('error', reject)
+    child.on('close', (code) => {
+      if (code !== 0 && options.allowFailure !== true) {
+        reject(new Error(`${command} ${args.join(' ')} exited ${code}\n${stdout}\n${stderr}`))
+        return
+      }
+      settle({ code, stdout, stderr })
+    })
+  })
+}
+
+/**
+ * PATH with every directory holding a `node` removed.
+ *
+ * This is the entire point of the job. Without it the binary could load Node
+ * from the runner and nothing would notice until a user without one tried it.
+ */
+function pathWithoutNode() {
+  const separator = IS_WINDOWS ? ';' : ':'
+  return (process.env.PATH ?? '')
+    .split(separator)
+    .filter((entry) => entry !== ''
+      && !existsSync(join(entry, 'node'))
+      && !existsSync(join(entry, 'node.exe')))
+    .join(separator)
+}
+
+const archive = resolve(flag('archive'))
+if (!existsSync(archive)) fail(`No archive at ${archive}.`)
+
+// Anchored on the platform tag rather than stopping at the first hyphen: a
+// prerelease version contains hyphens too, and a loose pattern reads
+// `0.5.1-linux` out of `looptroop-0.5.1-linux-x64`.
+const version = /^looptroop-(.+)-(?:linux|darwin|win)-(?:x64|arm64)\./.exec(basename(archive))?.[1]
+  ?? fail(`Cannot read a version out of ${basename(archive)}.`)
+
+const work = mkdtempSync(join(tmpdir(), 'looptroop-binsmoke-'))
+const configDir = join(work, 'config')
+const unpacked = join(work, 'unpacked')
+
+async function main() {
+  mkdirSync(unpacked, { recursive: true })
+
+  log(`Unpacking ${basename(archive)}...`)
+  if (archive.endsWith('.zip')) {
+    execFileSync('powershell', ['-NoProfile', '-Command',
+      `Expand-Archive -LiteralPath '${archive}' -DestinationPath '${unpacked}' -Force`,
+    ], { stdio: ['ignore', 'pipe', 'inherit'] })
+  } else {
+    execFileSync('tar', ['-xzf', archive, '-C', unpacked], { stdio: ['ignore', 'pipe', 'inherit'] })
+  }
+
+  const root = join(unpacked, readdirSync(unpacked)[0] ?? fail('The archive unpacked to nothing.'))
+  const binary = join(root, IS_WINDOWS ? 'looptroop.exe' : 'looptroop')
+  if (!existsSync(binary)) fail(`The archive contains no executable at ${binary}.`)
+
+  // Redistributing the embedded Node means shipping its licence. An archive
+  // without it is not one we may publish.
+  for (const required of ['LICENSE', 'LICENSE.node.txt', 'THIRD-PARTY-NOTICES.md']) {
+    if (!existsSync(join(root, required))) fail(`The archive is missing ${required}.`)
+  }
+  log('  carries the binary and every licence it must')
+
+  const env = {
+    PATH: pathWithoutNode(),
+    LOOPTROOP_CONFIG_DIR: configDir,
+    LOOPTROOP_OPENCODE_MODE: 'mock',
+  }
+  log('  (with every node removed from PATH)')
+
+  const reported = (await invoke(binary, ['--version'], { env })).stdout.trim()
+  if (reported !== version) fail(`The binary reports ${reported || '(nothing)'}, expected ${version}.`)
+  log(`  runs, and reports ${version}`)
+
+  const doctor = await invoke(binary, ['doctor', '--json'], { env, allowFailure: true })
+  let checks
+  try {
+    checks = JSON.parse(doctor.stdout).checks
+  } catch {
+    fail('`doctor --json` did not produce parseable JSON.', `${doctor.stdout}${doctor.stderr}`.slice(0, 2000))
+  }
+  const node = checks.find((check) => check.name === 'node')
+  log(`  \`doctor\` runs; embedded runtime ${node?.detail ?? '(unreported)'}`)
+
+  log('Starting the daemon...')
+  const started = await invoke(binary, ['start'], { env })
+  const url = /http:\/\/127\.0\.0\.1:(\d+)/.exec(started.stdout)?.[0]
+    ?? fail('`start` printed no address.', started.stdout)
+
+  try {
+    const status = await invoke(binary, ['status', '--json'], { env })
+    if (!status.stdout.includes(version)) fail('`status` does not report this version.', status.stdout)
+    log(`  running at ${url}`)
+
+    const index = await fetch(`${url}/`)
+    if (!index.ok) fail(`GET / returned ${index.status}; the interface is not embedded.`)
+    const html = await index.text()
+    log(`  serves the interface (${html.length} bytes)`)
+
+    // A build that embedded the document but not its assets serves a 200 here
+    // and a blank screen to a human.
+    const referenced = [...html.matchAll(/(?:src|href)="(\/[^"]+)"/g)].map((match) => match[1])
+    const unique = [...new Set(referenced)]
+    if (unique.length === 0) fail('The document references no assets, which cannot be right.')
+
+    const missing = []
+    for (const path of unique) {
+      const response = await fetch(`${url}${path}`)
+      if (!response.ok) missing.push(`${path} -> ${response.status}`)
+    }
+    if (missing.length > 0) fail(`${missing.length} of ${unique.length} referenced assets are missing.`, ...missing.slice(0, 10))
+    log(`  every referenced asset resolves (${unique.length} of ${unique.length})`)
+
+    // A missing asset must 404 rather than fall back to the document, or the
+    // browser reports a MIME-type error instead of the real problem.
+    const absent = await fetch(`${url}/assets/definitely-not-here-abc123.js`)
+    if (absent.status !== 404) fail(`A missing asset returned ${absent.status}, expected 404.`)
+    log('  a missing asset 404s rather than returning HTML')
+  } finally {
+    await invoke(binary, ['stop'], { env, allowFailure: true })
+  }
+
+  log(`\nPASS: ${basename(archive)} runs with no Node installed, serves its interface, and stops cleanly.`)
+}
+
+try {
+  await main()
+} finally {
+  rmSync(work, { recursive: true, force: true })
+}

--- a/scripts/smoke-binary.mjs
+++ b/scripts/smoke-binary.mjs
@@ -7,8 +7,9 @@
  *
  * The whole claim of this artefact is that it needs nothing installed, and
  * every GitHub runner has Node — so a binary that quietly shelled out to one
- * would pass a naive test and fail for the user it exists for. Node is removed
- * from PATH here, which is the only way the claim gets tested at all.
+ * would pass a naive test and fail for the user it exists for. `node` is
+ * shadowed here by a decoy that refuses to run, which is the only way the claim
+ * gets tested at all.
  *
  * The interface is checked properly rather than by fetching one page. A single-
  * file build carries the client inside it, and a build that embedded the
@@ -16,7 +17,7 @@
  * a human — so every asset the document references is fetched too.
  */
 import { spawn, execFileSync } from 'node:child_process'
-import { existsSync, mkdirSync, mkdtempSync, readdirSync, rmSync } from 'node:fs'
+import { chmodSync, existsSync, mkdirSync, mkdtempSync, readdirSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { basename, join, resolve } from 'node:path'
 
@@ -60,19 +61,33 @@ function invoke(command, args, options = {}) {
 }
 
 /**
- * PATH with every directory holding a `node` removed.
+ * A PATH where `node` resolves to something that refuses to run.
  *
- * This is the entire point of the job. Without it the binary could load Node
- * from the runner and nothing would notice until a user without one tried it.
+ * Proving this binary needs no Node is the entire point of the job, and the
+ * obvious approach — dropping every PATH directory that contains a `node` —
+ * is wrong in a way that only shows up on a real machine: `node` and `git`
+ * usually live in the same directory, so it takes git away too, and LoopTroop
+ * genuinely needs git. The failure then looks like a broken binary rather than
+ * a broken test.
+ *
+ * A decoy placed first is exact instead. Anything that tries to run `node`
+ * gets a loud non-zero exit, and every other tool still resolves normally.
  */
 function pathWithoutNode() {
-  const separator = IS_WINDOWS ? ';' : ':'
-  return (process.env.PATH ?? '')
-    .split(separator)
-    .filter((entry) => entry !== ''
-      && !existsSync(join(entry, 'node'))
-      && !existsSync(join(entry, 'node.exe')))
-    .join(separator)
+  const shadow = join(work, 'no-node')
+  mkdirSync(shadow, { recursive: true })
+
+  if (IS_WINDOWS) {
+    // Within one directory `.exe` beats `.cmd`, but across directories the
+    // first match wins — and this directory holds no `node.exe`.
+    writeFileSync(join(shadow, 'node.cmd'), '@echo off\r\necho This binary must not need Node. 1>&2\r\nexit /b 127\r\n')
+  } else {
+    const decoy = join(shadow, 'node')
+    writeFileSync(decoy, '#!/bin/sh\necho "This binary must not need Node." >&2\nexit 127\n')
+    chmodSync(decoy, 0o755)
+  }
+
+  return `${shadow}${IS_WINDOWS ? ';' : ':'}${process.env.PATH ?? ''}`
 }
 
 const archive = resolve(flag('archive'))
@@ -116,7 +131,7 @@ async function main() {
     LOOPTROOP_CONFIG_DIR: configDir,
     LOOPTROOP_OPENCODE_MODE: 'mock',
   }
-  log('  (with every node removed from PATH)')
+  log('  (with `node` shadowed by a decoy that refuses to run)')
 
   const reported = (await invoke(binary, ['--version'], { env })).stdout.trim()
   if (reported !== version) fail(`The binary reports ${reported || '(nothing)'}, expected ${version}.`)

--- a/scripts/smoke-winget.ts
+++ b/scripts/smoke-winget.ts
@@ -23,7 +23,7 @@ import { createServer } from 'node:http'
 import type { AddressInfo } from 'node:net'
 import { tmpdir } from 'node:os'
 import { basename, join, resolve } from 'node:path'
-import { renderWingetManifests, WINGET_IDENTIFIER } from './package-manifests.ts'
+import { renderWingetManifests } from './package-manifests.ts'
 
 class SmokeError extends Error {
   detail: string[]
@@ -167,12 +167,16 @@ async function main(): Promise<void> {
   log(`  \`doctor\` reports the winget channel: ${install?.detail}`)
 
   log('\nUninstalling...')
-  // `--accept-source-agreements` here too, not only on install: uninstall
-  // resolves the identifier against every configured source, and `msstore`
-  // refuses to be queried until its agreements are accepted — which reads as
-  // "operation cancelled" rather than as anything to do with our package.
+  // By manifest, symmetrically with the install, rather than by identifier.
+  // A package installed from a local manifest is not registered against any
+  // source, so `uninstall <id>` searches the configured sources, fails to find
+  // it, and reports "No installed package found matching input criteria" — a
+  // message about our package that is really about how it was installed.
+  //
+  // `--accept-source-agreements` because uninstall still consults `msstore`,
+  // which refuses to be queried until its agreements are accepted.
   await invoke('winget', [
-    'uninstall', WINGET_IDENTIFIER,
+    'uninstall', '--manifest', manifestDir,
     '--accept-source-agreements', '--disable-interactivity',
   ])
 

--- a/scripts/smoke-winget.ts
+++ b/scripts/smoke-winget.ts
@@ -167,7 +167,14 @@ async function main(): Promise<void> {
   log(`  \`doctor\` reports the winget channel: ${install?.detail}`)
 
   log('\nUninstalling...')
-  await invoke('winget', ['uninstall', WINGET_IDENTIFIER, '--disable-interactivity'])
+  // `--accept-source-agreements` here too, not only on install: uninstall
+  // resolves the identifier against every configured source, and `msstore`
+  // refuses to be queried until its agreements are accepted — which reads as
+  // "operation cancelled" rather than as anything to do with our package.
+  await invoke('winget', [
+    'uninstall', WINGET_IDENTIFIER,
+    '--accept-source-agreements', '--disable-interactivity',
+  ])
 
   if (existsSync(linkPath)) {
     fail(

--- a/scripts/smoke-winget.ts
+++ b/scripts/smoke-winget.ts
@@ -1,0 +1,195 @@
+#!/usr/bin/env node
+/**
+ * Installs LoopTroop through WinGet from a local manifest, drives it, and
+ * uninstalls it again.
+ *
+ *   node scripts/smoke-winget.ts --archive dist-binary/looptroop-9.9.9-win-x64.zip
+ *
+ * From manifests rendered here and the archive served on loopback, never the
+ * public `winget-pkgs` repository — the same trick the Homebrew and Scoop
+ * smokes use with a throwaway tap and bucket. A submission there is a pull
+ * request reviewed by humans, so the package has to be proved before it is
+ * offered rather than after.
+ *
+ * This channel installs the standalone binary rather than the bundle the other
+ * three take, and not by preference: `winget validate` refuses a portable whose
+ * `RelativeFilePath` is anything but an `.exe`, and rejected the bundle's
+ * `.cmd` shim outright. That rejection is what this job exists to keep catching.
+ */
+import { spawn } from 'node:child_process'
+import { createHash } from 'node:crypto'
+import { createReadStream, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { createServer } from 'node:http'
+import type { AddressInfo } from 'node:net'
+import { tmpdir } from 'node:os'
+import { basename, join, resolve } from 'node:path'
+import { renderWingetManifests, WINGET_IDENTIFIER } from './package-manifests.ts'
+
+class SmokeError extends Error {
+  detail: string[]
+
+  constructor(message: string, detail: string[]) {
+    super(message)
+    this.name = 'SmokeError'
+    this.detail = detail
+  }
+}
+
+function fail(message: string, ...detail: string[]): never {
+  throw new SmokeError(message, detail.filter(Boolean))
+}
+
+function log(message: string): void {
+  process.stdout.write(`${message}\n`)
+}
+
+function flag(name: string): string {
+  const index = process.argv.indexOf(`--${name}`)
+  const value = index === -1 ? undefined : process.argv[index + 1]
+  if (value === undefined || value.startsWith('--')) fail(`--${name} is required.`)
+  return value
+}
+
+interface RunResult { code: number | null, stdout: string, stderr: string }
+
+/**
+ * Always async, never `spawnSync`: this process is also the HTTP server the
+ * child downloads from, so a synchronous child deadlocks and surfaces as a
+ * network timeout rather than as a hang.
+ */
+function invoke(command: string, args: string[], options: { allowFailure?: boolean, env?: NodeJS.ProcessEnv } = {}): Promise<RunResult> {
+  return new Promise((settle, reject) => {
+    const child = spawn(command, args, { env: { ...process.env, ...options.env } })
+    let stdout = ''
+    let stderr = ''
+    child.stdout.on('data', (chunk: Buffer) => { stdout += chunk.toString() })
+    child.stderr.on('data', (chunk: Buffer) => { stderr += chunk.toString() })
+    child.on('error', reject)
+    child.on('close', (code) => {
+      if (code !== 0 && options.allowFailure !== true) {
+        reject(new SmokeError(`${command} ${args.join(' ')} exited ${String(code)}.`, [stdout, stderr]))
+        return
+      }
+      settle({ code, stdout, stderr })
+    })
+  })
+}
+
+if (process.platform !== 'win32') fail('WinGet exists only on Windows.')
+
+const archivePath = resolve(flag('archive'))
+if (!existsSync(archivePath)) fail(`No archive at ${archivePath}.`)
+
+const archiveName = basename(archivePath)
+const version = /^looptroop-(.+)-win-x64\.zip$/.exec(archiveName)?.[1]
+  ?? fail(`Cannot read a version out of ${archiveName}.`)
+const sha256 = createHash('sha256').update(readFileSync(archivePath)).digest('hex')
+
+const work = mkdtempSync(join(tmpdir(), 'looptroop-winget-'))
+const manifestDir = join(work, 'manifests')
+const configDir = join(work, 'config')
+const childEnv = { LOOPTROOP_CONFIG_DIR: configDir, LOOPTROOP_OPENCODE_MODE: 'mock' }
+
+/** A release-shaped path, so this exercises the URL a real manifest carries. */
+const assetPath = `/looptroop-ai/LoopTroop/releases/download/v${version}/${archiveName}`
+
+const server = createServer((request, response) => {
+  if (request.url !== assetPath) {
+    response.writeHead(404).end()
+    return
+  }
+  response.writeHead(200, { 'content-type': 'application/zip' })
+  createReadStream(archivePath).pipe(response)
+})
+
+/** Where WinGet puts the alias for a portable package. */
+const linkPath = join(
+  process.env.LOCALAPPDATA ?? join(process.env.USERPROFILE ?? 'C:\\', 'AppData', 'Local'),
+  'Microsoft', 'WinGet', 'Links', 'looptroop.exe',
+)
+
+async function main(): Promise<void> {
+  await new Promise<void>((done) => server.listen(0, '127.0.0.1', done))
+  const url = `http://127.0.0.1:${(server.address() as AddressInfo).port}${assetPath}`
+  log(`Serving ${archiveName} at ${url}\n`)
+
+  mkdirSync(manifestDir, { recursive: true })
+  const manifests = renderWingetManifests({ version, url, sha256 })
+  for (const [name, contents] of Object.entries(manifests)) {
+    writeFileSync(join(manifestDir, name), contents)
+  }
+  log(`Rendered ${Object.keys(manifests).length} manifests`)
+
+  // Schema first. A manifest that does not validate is rejected by the
+  // submission pipeline before a human sees it, and the error there is far less
+  // legible than the one here.
+  const validated = await invoke('winget', ['validate', '--manifest', manifestDir], { allowFailure: true })
+  log(`${validated.stdout}${validated.stderr}`.trim())
+  if (validated.code !== 0) fail('`winget validate` rejected the rendered manifests.')
+  log('  manifests validate\n')
+
+  // `--skip-dependencies`: the declaration is covered by the golden files and
+  // by validation. What this proves is our archive and our shim, and resolving
+  // git here would make the job depend on the public WinGet source.
+  log('Installing from the local manifest...')
+  await invoke('winget', [
+    'install', '--manifest', manifestDir,
+    '--accept-package-agreements', '--accept-source-agreements',
+    '--disable-interactivity', '--skip-dependencies',
+  ])
+
+  if (!existsSync(linkPath)) fail(`WinGet installed without producing an alias at ${linkPath}.`)
+  log(`  alias created at ${linkPath}`)
+
+  const reported = (await invoke(linkPath, ['--version'], { env: childEnv })).stdout.trim()
+  if (reported !== version) fail(`The installed command reports ${reported || '(nothing)'}, expected ${version}.`)
+  log(`  runs, and reports ${version}`)
+
+  // `--json` rather than scraping the human report: this reads the install
+  // check itself instead of searching the output for two words that could
+  // co-occur in an unrelated remedy line.
+  const doctor = await invoke(linkPath, ['doctor', '--json'], { env: childEnv, allowFailure: true })
+  let checks: { name?: string, detail?: string }[]
+  try {
+    checks = JSON.parse(doctor.stdout).checks
+  } catch {
+    fail('`doctor --json` did not produce parseable JSON.', `${doctor.stdout}${doctor.stderr}`.slice(0, 2000))
+  }
+
+  const install = checks.find((check) => check.name === 'install')
+  if (!/^winget\b/.test(install?.detail ?? '')) {
+    fail(
+      '`doctor` does not report this as a winget install.',
+      `It reports: ${install?.detail ?? '(no install check)'}`,
+      'That means the upgrade command shown to the user is the wrong one.',
+    )
+  }
+  log(`  \`doctor\` reports the winget channel: ${install?.detail}`)
+
+  log('\nUninstalling...')
+  await invoke('winget', ['uninstall', WINGET_IDENTIFIER, '--disable-interactivity'])
+
+  if (existsSync(linkPath)) {
+    fail(
+      `Uninstalling left an alias behind at ${linkPath}.`,
+      'It will keep answering `looptroop` with a path that no longer exists.',
+    )
+  }
+  log('  alias removed')
+
+  log(`\nPASS: winget installs ${version} from a portable zip, it runs, it knows which `
+    + 'channel it came from, and uninstalling cleans up after itself.')
+}
+
+try {
+  await main()
+} catch (error) {
+  if (!(error instanceof SmokeError)) throw error
+  process.stderr.write(`\nFAIL: ${error.message}\n`)
+  for (const line of error.detail) process.stderr.write(`  ${line}\n`)
+  process.stderr.write('\n')
+  process.exitCode = 1
+} finally {
+  server.close()
+  rmSync(work, { recursive: true, force: true })
+}

--- a/scripts/winget-submit.ts
+++ b/scripts/winget-submit.ts
@@ -1,0 +1,133 @@
+#!/usr/bin/env node
+/**
+ * Submits this version's WinGet manifests as a pull request into
+ * `microsoft/winget-pkgs`.
+ *
+ *   node scripts/winget-submit.ts --version 1.2.3 --url https://…/looptroop-1.2.3-win-x64.zip --sha256 …
+ *
+ * Unlike Homebrew, Scoop and Chocolatey, this is not a write we control. It is
+ * a pull request into a repository Microsoft owns, reviewed by people on their
+ * schedule — so this reports a submission and never waits for an outcome, the
+ * same bargain the Chocolatey job makes with moderation.
+ *
+ * ## Retry-safe by construction
+ *
+ * A re-run of a release must not open a second pull request for the same
+ * version. Before pushing, this looks for an open one from our fork for this
+ * exact version and stops if it finds it. The branch name is derived from the
+ * version too, so a re-push updates the same branch rather than accumulating
+ * new ones.
+ *
+ * ## Why `git` and the API rather than wingetcreate
+ *
+ * `wingetcreate` builds manifests by inspecting an installer and interviewing
+ * the user. Ours are rendered from the release manifest by the same code that
+ * renders the other three descriptors, and that property — one place decides
+ * what a version's bytes are — is worth more than the convenience. So this
+ * pushes files we already have and opens the pull request itself.
+ */
+import { execFileSync } from 'node:child_process'
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { renderWingetManifests, WINGET_IDENTIFIER, wingetManifestDir } from './package-manifests.ts'
+
+const UPSTREAM = 'microsoft/winget-pkgs'
+const FORK = 'looptroop-ai/winget-pkgs'
+
+function fail(message: string, ...detail: string[]): never {
+  process.stderr.write(`::error::${message}\n`)
+  for (const line of detail) process.stderr.write(`  ${line}\n`)
+  process.exit(1)
+}
+
+function log(message: string): void {
+  process.stdout.write(`${message}\n`)
+}
+
+function flag(name: string): string {
+  const index = process.argv.indexOf(`--${name}`)
+  const value = index === -1 ? undefined : process.argv[index + 1]
+  if (value === undefined || value.startsWith('--')) fail(`--${name} is required.`)
+  return value
+}
+
+function run(command: string, args: string[], options: { cwd?: string, allowFailure?: boolean } = {}): string {
+  try {
+    return execFileSync(command, args, { cwd: options.cwd, encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] })
+  } catch (error) {
+    if (options.allowFailure === true) return ''
+    const detail = error instanceof Error && 'stderr' in error ? String((error as { stderr?: unknown }).stderr ?? '') : ''
+    fail(`${command} ${args.join(' ')} failed.`, detail)
+  }
+}
+
+const token = process.env.WINGET_TOKEN ?? fail('WINGET_TOKEN is not set.')
+const version = flag('version')
+const url = flag('url')
+const sha256 = flag('sha256')
+
+const branch = `looptroop-${version}`
+const work = mkdtempSync(join(tmpdir(), 'looptroop-winget-submit-'))
+
+try {
+  // Already open? A release re-run must reconcile rather than duplicate.
+  const existing = run('gh', [
+    'pr', 'list', '--repo', UPSTREAM, '--state', 'open',
+    '--head', `${FORK.split('/')[0]}:${branch}`, '--json', 'number,url',
+  ], { allowFailure: true }).trim()
+
+  if (existing !== '' && existing !== '[]') {
+    log(`A pull request for ${version} is already open: ${existing}`)
+    log('Nothing to do; a re-run must not open a second one.')
+    process.exit(0)
+  }
+
+  // A shallow clone of the fork's default branch. The repository is enormous —
+  // a full history would be gigabytes for a directory of three small files.
+  log(`Cloning ${FORK} (shallow)...`)
+  const repo = join(work, 'winget-pkgs')
+  run('git', ['clone', '--depth', '1', `https://x-access-token:${token}@github.com/${FORK}.git`, repo])
+
+  // Reset onto upstream so the fork being stale cannot carry unrelated changes
+  // into the pull request.
+  run('git', ['remote', 'add', 'upstream', `https://github.com/${UPSTREAM}.git`], { cwd: repo })
+  run('git', ['fetch', '--depth', '1', 'upstream', 'master'], { cwd: repo })
+  run('git', ['checkout', '-B', branch, 'upstream/master'], { cwd: repo })
+
+  const directory = join(repo, wingetManifestDir(version))
+  mkdirSync(directory, { recursive: true })
+  for (const [name, contents] of Object.entries(renderWingetManifests({ version, url, sha256 }))) {
+    writeFileSync(join(directory, name), contents)
+  }
+  log(`Wrote ${wingetManifestDir(version)}`)
+
+  run('git', ['config', 'user.name', 'looptroop-ai'], { cwd: repo })
+  run('git', ['config', 'user.email', 'noreply@looptroop.ovh'], { cwd: repo })
+  run('git', ['add', wingetManifestDir(version)], { cwd: repo })
+  run('git', ['commit', '-m', `New version: ${WINGET_IDENTIFIER} version ${version}`], { cwd: repo })
+  run('git', ['push', '--force-with-lease', 'origin', branch], { cwd: repo })
+
+  const pr = run('gh', [
+    'pr', 'create',
+    '--repo', UPSTREAM,
+    '--head', `${FORK.split('/')[0]}:${branch}`,
+    '--base', 'master',
+    '--title', `New version: ${WINGET_IDENTIFIER} version ${version}`,
+    '--body', [
+      `Adds ${WINGET_IDENTIFIER} ${version}.`,
+      '',
+      'Manifests are generated from the release manifest by the same code that',
+      'renders this project\'s Homebrew, Scoop and Chocolatey descriptors, so the',
+      'installer URL and checksum come from one source of truth.',
+      '',
+      'The installer is a portable executable in a zip; it carries its own Node',
+      'runtime, so only git is declared as a dependency.',
+    ].join('\n'),
+  ], { cwd: repo }).trim()
+
+  log(`\nSubmitted: ${pr}`)
+  log('Acceptance is a review queue, not a result. Nothing waits on it.')
+} finally {
+  rmSync(work, { recursive: true, force: true })
+}

--- a/scripts/winget-submit.ts
+++ b/scripts/winget-submit.ts
@@ -52,9 +52,22 @@ function flag(name: string): string {
   return value
 }
 
+const token = process.env.WINGET_TOKEN ?? fail('WINGET_TOKEN is not set.')
+
+/**
+ * `GH_TOKEN` is set from `WINGET_TOKEN` for every child, because `gh` reads
+ * that name and this job deliberately does not have the workflow's own token:
+ * the pull request is opened against a repository we do not own, by a
+ * credential that exists for exactly that purpose.
+ */
 function run(command: string, args: string[], options: { cwd?: string, allowFailure?: boolean } = {}): string {
   try {
-    return execFileSync(command, args, { cwd: options.cwd, encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] })
+    return execFileSync(command, args, {
+      cwd: options.cwd,
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+      env: { ...process.env, GH_TOKEN: token },
+    })
   } catch (error) {
     if (options.allowFailure === true) return ''
     const detail = error instanceof Error && 'stderr' in error ? String((error as { stderr?: unknown }).stderr ?? '') : ''
@@ -62,7 +75,6 @@ function run(command: string, args: string[], options: { cwd?: string, allowFail
   }
 }
 
-const token = process.env.WINGET_TOKEN ?? fail('WINGET_TOKEN is not set.')
 const version = flag('version')
 const url = flag('url')
 const sha256 = flag('sha256')

--- a/server/app.ts
+++ b/server/app.ts
@@ -1,6 +1,7 @@
 import { Hono, type Context } from 'hono'
 import { cors } from 'hono/cors'
 import { serveStatic } from '@hono/node-server/serve-static'
+import { embeddedAsset, embeddedIndex, hasEmbeddedClient } from './lib/seaAssets'
 import { existsSync } from 'node:fs'
 import { readFile } from 'node:fs/promises'
 import { dirname, resolve } from 'node:path'
@@ -268,7 +269,40 @@ export function createApp(options: CreateAppOptions = {}): Hono {
   app.route('/api', workflowRouter)
 
   // Mounted after the API so a frontend route can never shadow an endpoint.
-  if (mode === 'production') {
+  //
+  // A single-file build has no `dist/client` beside it — no directory at all —
+  // so the interface travels inside the executable and is served from there.
+  // Everything below this branch is the ordinary on-disk path, unchanged.
+  if (mode === 'production' && hasEmbeddedClient()) {
+    app.on(['GET', 'HEAD'], '/*', async (c, next) => {
+      // An unmatched endpoint is a 404, not a frontend route.
+      if (c.req.path === '/api' || c.req.path.startsWith('/api/')) return next()
+
+      const asset = embeddedAsset(c.req.path)
+      if (asset) {
+        // Asset filenames carry a content hash, so a stale response is
+        // impossible; the document must always be revalidated, or a cached copy
+        // would keep pointing at asset hashes that no longer exist.
+        const immutable = c.req.path.startsWith('/assets/')
+        return c.body(asset.body, 200, {
+          'Content-Type': asset.contentType,
+          'Cache-Control': immutable ? 'public, max-age=31536000, immutable' : 'no-cache',
+        })
+      }
+
+      // A missing hashed asset must 404 rather than fall back to HTML, or the
+      // browser reports a module MIME-type error instead of the real problem.
+      if (c.req.path.startsWith('/assets/')) return next()
+      if (!wantsSpaDocument(c.req.path, c.req.header('accept'))) return next()
+
+      const index = embeddedIndex()
+      if (!index) return next()
+      return c.body(index.body, 200, {
+        'Content-Type': index.contentType,
+        'Cache-Control': 'no-cache',
+      })
+    })
+  } else if (mode === 'production') {
     const clientDir = options.clientDir ?? resolveDefaultClientDir()
     const indexHtml = resolve(clientDir, 'index.html')
 

--- a/server/cli/cli.ts
+++ b/server/cli/cli.ts
@@ -1,7 +1,6 @@
 import { parseArgs } from 'node:util'
-import { readFileSync } from 'node:fs'
-import { dirname, resolve } from 'node:path'
-import { fileURLToPath } from 'node:url'
+import { APP_VERSION } from '../lib/appVersion'
+import { DAEMON_ARGV } from './daemonHandoff'
 
 const USAGE = `LoopTroop — local AI coding orchestration
 
@@ -30,18 +29,18 @@ Options:
   --help         Print this message
 `
 
-function readVersion(): string {
-  try {
-    // dist/server/cli/cli.js -> package root is three levels up.
-    const manifestPath = resolve(dirname(fileURLToPath(import.meta.url)), '../../../package.json')
-    const manifest = JSON.parse(readFileSync(manifestPath, 'utf8')) as { version?: string }
-    return manifest.version ?? '0.0.0'
-  } catch {
-    return '0.0.0'
-  }
-}
-
 export async function main(argv: string[]): Promise<number> {
+  // Before `parseArgs`, and before anything else. Under npm this file is the
+  // script Node was given; inside a single-file build it is the executable
+  // itself, and in that case there is no second file to spawn — the binary has
+  // to be able to become the daemon on request. One handler serves both, so
+  // there is no second start implementation to keep in step.
+  if (argv[0] === DAEMON_ARGV) {
+    const { runDaemonProcess } = await import('./daemonProcess')
+    await runDaemonProcess()
+    return 0
+  }
+
   let parsed
   try {
     parsed = parseArgs({
@@ -69,7 +68,7 @@ export async function main(argv: string[]): Promise<number> {
   const command = positionals[0]
 
   if (values.version) {
-    process.stdout.write(`${readVersion()}\n`)
+    process.stdout.write(`${APP_VERSION}\n`)
     return 0
   }
 

--- a/server/cli/commands.ts
+++ b/server/cli/commands.ts
@@ -1,7 +1,5 @@
 import { spawn, type ChildProcess } from 'node:child_process'
 import { openSync } from 'node:fs'
-import { dirname, resolve } from 'node:path'
-import { fileURLToPath } from 'node:url'
 import { setTimeout as delay } from 'node:timers/promises'
 import { readDaemonState, getDaemonLogPath, getDaemonLogDir, clearDaemonState, clearStaleDaemonState, readDaemonStartFailure, redactDaemonState, type DaemonState } from '../lib/daemonPaths'
 import { resolveAppConfigDir, ensureSecureDir } from '../lib/appConfigDir'
@@ -9,6 +7,7 @@ import { rotateDaemonLog } from '../lib/daemonLog'
 import { checkForUpdate, formatUpdateNotice } from '../lib/updateCheck'
 import { clearLockOwnedBy, releaseStaleLock } from '../lib/daemonLock'
 import { matchProcess, readProcessStartToken } from '../lib/processIdentity'
+import { daemonArgv } from './daemonHandoff'
 import { isProcessAlive, killProcessTree, signalTermination, waitForExit } from './processControl'
 
 /** A start is abandoned rather than hanging forever if the child never reports. */
@@ -36,10 +35,6 @@ export const DEFAULT_STOP_BUDGETS: StopBudgets = {
 export interface CliOptions {
   port?: number
   foreground?: boolean
-}
-
-function moduleDir(): string {
-  return dirname(fileURLToPath(import.meta.url))
 }
 
 /**
@@ -128,7 +123,7 @@ export async function startCommand(options: CliOptions = {}): Promise<number> {
   // file rather than to a pipe that dies with the parent.
   const logFd = openSync(logPath, 'a')
 
-  const child = spawn(process.execPath, [resolve(moduleDir(), 'daemonProcess.js')], {
+  const child = spawn(process.execPath, daemonArgv(), {
     detached: true,
     stdio: ['ignore', logFd, logFd],
     env: {

--- a/server/cli/daemonHandoff.ts
+++ b/server/cli/daemonHandoff.ts
@@ -1,0 +1,47 @@
+import { resolve } from 'node:path'
+import { isSea } from '../lib/isSea'
+
+/**
+ * How `start` hands off to the detached process that becomes the daemon.
+ *
+ * Its own module rather than living beside either caller: the CLI entry
+ * dispatches on it and `startCommand` produces it, and putting it in one of
+ * those would make the two import each other.
+ */
+
+/**
+ * The argument this program re-invokes itself with to become the daemon.
+ *
+ * Deliberately not a documented command — it is an implementation detail of how
+ * a detached child is created, and running it by hand does nothing a user
+ * wants. The leading underscores keep it out of the usage text and make an
+ * accidental collision with a real command name impossible.
+ */
+export const DAEMON_ARGV = '__daemon'
+
+/**
+ * The arguments to pass `process.execPath` so the child becomes the daemon.
+ *
+ * `process.execPath` is not the same thing in the two builds, which is the
+ * whole reason this exists. Under npm it is `node`, so the script has to be
+ * named too — and this used to name a *second* file, `daemonProcess.js`, which
+ * sits beside the CLI only because npm unpacks a directory. Inside a
+ * single-file build there is no such file and `process.execPath` is the
+ * executable itself, so that spawn re-invoked LoopTroop with a path that does
+ * not exist as its first argument, and `start` waited out its readiness
+ * timeout reporting a failure with no cause.
+ *
+ * `isSea()` is what separates the two: in a single-file build `argv[1]` is the
+ * executable rather than a script, so passing it along would run the binary
+ * against itself.
+ */
+export function daemonArgv(): string[] {
+  if (isSea()) return [DAEMON_ARGV]
+
+  // `argv[1]` is the script Node was given — the CLI entry, whatever it is
+  // called and wherever it was installed. Read rather than assumed, so this
+  // keeps working from `dist/`, from a global install and under `tsx`.
+  const entry = process.argv[1]
+  if (entry === undefined) throw new Error('Cannot start the daemon: this process has no entry script.')
+  return [resolve(entry), DAEMON_ARGV]
+}

--- a/server/cli/daemonProcess.ts
+++ b/server/cli/daemonProcess.ts
@@ -1,21 +1,8 @@
-import { readFileSync } from 'node:fs'
-import { dirname, resolve } from 'node:path'
-import { fileURLToPath } from 'node:url'
 import { isEntryPoint } from './entryPoint'
+import { APP_VERSION } from '../lib/appVersion'
 import { startDaemon, installShutdownHandlers } from '../daemon/startDaemon'
 import { startDaemonLogRotation } from '../lib/daemonLog'
 import { resolveSettings } from '../lib/appSettings'
-
-function readVersion(): string {
-  try {
-    // dist/server/cli/daemonProcess.js -> package root is three levels up.
-    const manifestPath = resolve(dirname(fileURLToPath(import.meta.url)), '../../../package.json')
-    const manifest = JSON.parse(readFileSync(manifestPath, 'utf8')) as { version?: string }
-    return manifest.version ?? '0.0.0'
-  } catch {
-    return '0.0.0'
-  }
-}
 
 export interface DaemonProcessOptions {
   port?: number
@@ -52,7 +39,7 @@ export async function runDaemonProcess(options: DaemonProcessOptions = {}): Prom
 
   const handle = await startDaemon({
     settings,
-    version: readVersion(),
+    version: APP_VERSION,
     onReady: (state) => {
       console.log(`[daemon] Serving on http://${state.host}:${state.port} (pid ${state.pid}).`)
     },

--- a/server/lib/appVersion.ts
+++ b/server/lib/appVersion.ts
@@ -1,0 +1,48 @@
+import { readFileSync } from 'node:fs'
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+/**
+ * The application version, compiled in rather than read off disk.
+ *
+ * Two callers used to resolve `package.json` three levels up from their own
+ * module and parse it. That works for an npm install, where the module really
+ * does sit inside the package, and produces `0.0.0` everywhere else — most
+ * importantly inside a single-file build, where there is no `package.json` on
+ * disk at all and the path it would look at is the executable's.
+ *
+ * `0.0.0` is the worst possible failure here: `--version` still answers, the
+ * update check still runs, and both are silently wrong.
+ *
+ * The build replaces `__LOOPTROOP_VERSION__` with a literal. The filesystem
+ * read stays as the fallback for `tsx`, for the test suite, and for anyone
+ * running the sources directly — none of which go through a bundler.
+ */
+declare const __LOOPTROOP_VERSION__: string | undefined
+
+function readFromPackageJson(): string {
+  try {
+    // dist/server/lib/appVersion.js -> package root is three levels up, and
+    // server/lib/appVersion.ts -> two. Both are tried rather than guessing
+    // which build this is.
+    const here = dirname(fileURLToPath(import.meta.url))
+    for (const up of ['../../..', '../..']) {
+      try {
+        const manifest = JSON.parse(readFileSync(resolve(here, up, 'package.json'), 'utf8')) as { name?: string, version?: string }
+        // Any `package.json` will parse; only ours is the right answer. Without
+        // this check a bundle sitting inside somebody else's package would
+        // report their version.
+        if (manifest.name === 'looptroop' && typeof manifest.version === 'string') return manifest.version
+      } catch {
+        continue
+      }
+    }
+  } catch {
+    // Falls through to the placeholder below.
+  }
+  return '0.0.0'
+}
+
+export const APP_VERSION: string = typeof __LOOPTROOP_VERSION__ === 'string'
+  ? __LOOPTROOP_VERSION__
+  : readFromPackageJson()

--- a/server/lib/installChannel.ts
+++ b/server/lib/installChannel.ts
@@ -114,7 +114,13 @@ function detectFromShape(moduleDir: string): InstallChannel {
   // WinGet unpacks a portable archive and runs nothing afterwards, so unlike
   // the other three it cannot leave a marker file behind. The install path is
   // the only evidence there is, and WinGet owns this directory outright.
-  if (/\/WinGet\/Packages\//i.test(normalized)) return 'winget'
+  //
+  // Both `Packages` and `Links`, because a portable is reached through an alias
+  // WinGet puts in `Links` and the running executable resolves to that rather
+  // than to the unpacked copy. Matching only `Packages` made a WinGet install
+  // report itself as a plain downloaded binary — right about the artifact,
+  // wrong about the upgrade command, which is the whole point of asking.
+  if (/\/Microsoft\/WinGet\//i.test(normalized)) return 'winget'
   if (/\/node_modules\/looptroop\//.test(normalized)) return 'npm'
 
   // A checkout has the sources a published package never ships.

--- a/server/lib/installChannel.ts
+++ b/server/lib/installChannel.ts
@@ -2,8 +2,9 @@ import { dirname, resolve, sep } from 'node:path'
 import { existsSync, readFileSync } from 'node:fs'
 import { fileURLToPath } from 'node:url'
 import { readSettingsFile, writeSettingsFile } from './appSettings'
+import { isSea } from './isSea'
 
-export type InstallChannel = 'npm' | 'homebrew' | 'scoop' | 'chocolatey' | 'winget' | 'container' | 'source' | 'unknown'
+export type InstallChannel = 'npm' | 'homebrew' | 'scoop' | 'chocolatey' | 'winget' | 'binary' | 'container' | 'source' | 'unknown'
 
 export interface InstallInfo {
   channel: InstallChannel
@@ -19,6 +20,10 @@ const UPGRADE_COMMANDS: Record<InstallChannel, string> = {
   // `looptroop stop` first, because Windows will not replace a running
   // executable and the daemon holds this one open.
   winget: 'looptroop stop && winget upgrade LoopTroopAI.LoopTroop',
+  // A directly downloaded binary was put wherever its owner chose, and nothing
+  // records where. Re-running the installer is the one instruction that is
+  // true regardless.
+  binary: 'Re-run the installer from https://www.looptroop.ovh/install',
   container: 'docker pull looptroopai/looptroop:latest',
   source: 'git pull && npm install && npm run build',
   unknown: 'See https://www.looptroop.ovh for upgrade instructions',
@@ -93,6 +98,11 @@ function detectFromMarkers(moduleDir: string): InstallChannel | null {
 function detectFromShape(moduleDir: string): InstallChannel {
   const normalized = moduleDir.split(sep).join('/')
 
+  // Path patterns first, because a package manager that unpacked a binary owns
+  // its directory and that is stronger evidence than the artifact's own shape.
+  // `isSea()` only says *what* this is, never where it came from — a binary
+  // from WinGet, from a tarball and from Nix are all single-file builds.
+
   // Only the Cellar, never a bare `/homebrew/`: on a Mac whose Node came from
   // Homebrew, a plain `npm install -g` lands in
   // `/opt/homebrew/lib/node_modules/looptroop`, which the loose pattern called
@@ -112,6 +122,12 @@ function detectFromShape(moduleDir: string): InstallChannel {
   if (packageRoot !== null && existsSync(resolve(packageRoot, 'server')) && existsSync(resolve(packageRoot, '.git'))) {
     return 'source'
   }
+
+  // Last, and only once every path has been ruled out. A single-file build that
+  // no package manager owns was downloaded and put somewhere by hand, and
+  // `binary` is the honest answer for it. Checked here rather than first
+  // precisely because being a single-file build says nothing about provenance.
+  if (isSea()) return 'binary'
 
   return 'unknown'
 }

--- a/server/lib/isSea.ts
+++ b/server/lib/isSea.ts
@@ -1,0 +1,22 @@
+import { isSea as nodeIsSea } from 'node:sea'
+
+/**
+ * Whether this process is a single-file build rather than Node running scripts.
+ *
+ * `node:sea` is an ordinary builtin — present whether or not the process is a
+ * single-file application, answering `false` when it is not — so this needs no
+ * guard and no dynamic import.
+ *
+ * This says what the *artifact* is, never where it came from. A binary
+ * downloaded directly, one installed by WinGet and one installed by Nix are all
+ * single-file builds, so `installChannel` stays a separate question with a
+ * separate answer.
+ */
+export function isSea(): boolean {
+  try {
+    return nodeIsSea()
+  } catch {
+    // Defensive only: the builtin exists on every Node this package supports.
+    return false
+  }
+}

--- a/server/lib/seaAssets.ts
+++ b/server/lib/seaAssets.ts
@@ -1,0 +1,90 @@
+import { getAssetKeys, getRawAsset } from 'node:sea'
+import { isSea } from './isSea'
+
+/**
+ * The built interface, read out of the executable instead of off disk.
+ *
+ * A single-file build has no `dist/client` beside it — it has no directory at
+ * all — so the walk that finds the interface in an npm install returns nothing
+ * and every page is a 404 while the API answers normally. That failure is
+ * invisible to anything except a request for an actual document, which is why
+ * the spike asserts a page rather than only a version.
+ *
+ * Assets are embedded under `client/…` keys mirroring the built tree, so the
+ * mapping from a request path to a key is a lookup rather than a guess. Vite
+ * hashes asset filenames, so there is nothing to invalidate on upgrade: a new
+ * build embeds new keys.
+ */
+const PREFIX = 'client/'
+
+/** Enough to cover what Vite emits; anything else is served as bytes. */
+const CONTENT_TYPES: Record<string, string> = {
+  '.html': 'text/html; charset=utf-8',
+  '.js': 'text/javascript; charset=utf-8',
+  '.mjs': 'text/javascript; charset=utf-8',
+  '.css': 'text/css; charset=utf-8',
+  '.json': 'application/json; charset=utf-8',
+  '.svg': 'image/svg+xml',
+  '.png': 'image/png',
+  '.jpg': 'image/jpeg',
+  '.jpeg': 'image/jpeg',
+  '.gif': 'image/gif',
+  '.webp': 'image/webp',
+  '.ico': 'image/vnd.microsoft.icon',
+  '.woff': 'font/woff',
+  '.woff2': 'font/woff2',
+  '.ttf': 'font/ttf',
+  '.map': 'application/json; charset=utf-8',
+  '.txt': 'text/plain; charset=utf-8',
+  '.webmanifest': 'application/manifest+json',
+}
+
+function contentTypeFor(path: string): string {
+  const dot = path.lastIndexOf('.')
+  return (dot === -1 ? undefined : CONTENT_TYPES[path.slice(dot).toLowerCase()])
+    ?? 'application/octet-stream'
+}
+
+/**
+ * Read once. `getAssetKeys` is cheap, but the answer cannot change while the
+ * process runs, and every request would otherwise pay for it.
+ */
+let keys: Set<string> | null = null
+
+function assetKeys(): Set<string> {
+  if (keys === null) {
+    keys = isSea() ? new Set(getAssetKeys()) : new Set<string>()
+  }
+  return keys
+}
+
+/** Whether this build carries an embedded interface at all. */
+export function hasEmbeddedClient(): boolean {
+  return assetKeys().has(`${PREFIX}index.html`)
+}
+
+export interface EmbeddedAsset {
+  body: ArrayBuffer
+  contentType: string
+}
+
+/**
+ * An embedded asset by request path, or `null` when there is no such asset.
+ *
+ * The leading slash is stripped and the path is looked up verbatim: no walking,
+ * no normalisation beyond that, so `..` cannot reach a key it should not — the
+ * key either exists in the set or it does not.
+ */
+export function embeddedAsset(requestPath: string): EmbeddedAsset | null {
+  if (!isSea()) return null
+
+  const key = `${PREFIX}${requestPath.replace(/^\/+/, '')}`
+  if (!assetKeys().has(key)) return null
+
+  return { body: getRawAsset(key), contentType: contentTypeFor(key) }
+}
+
+/** The SPA document, for deep links that have no file behind them. */
+export function embeddedIndex(): EmbeddedAsset | null {
+  return embeddedAsset('/index.html')
+}

--- a/tests/daemonHandoff.test.ts
+++ b/tests/daemonHandoff.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { resolve } from 'node:path'
+
+/**
+ * How `start` re-invokes this program to become the daemon.
+ *
+ * The bug this replaces: `spawn(process.execPath, [resolve(moduleDir(),
+ * 'daemonProcess.js')])`. Under npm that is `node <dir>/daemonProcess.js`,
+ * which works only because npm unpacks a directory of files. Inside a
+ * single-file build `process.execPath` is the executable and there is no second
+ * file, so it re-invoked LoopTroop with a path that does not exist as its first
+ * argument — `start` then waited out its readiness timeout and reported a
+ * failure with no cause in the log.
+ */
+const seaMock = vi.hoisted(() => ({ value: false }))
+vi.mock('../server/lib/isSea', () => ({ isSea: () => seaMock.value }))
+
+const { DAEMON_ARGV, daemonArgv } = await import('../server/cli/daemonHandoff')
+
+afterEach(() => {
+  seaMock.value = false
+})
+
+describe('handing off to the daemon', () => {
+  it('names the entry script as well as the argument under npm', () => {
+    const argv = process.argv
+    process.argv = ['/usr/bin/node', '/usr/local/lib/node_modules/looptroop/dist/server/cli/cli.js']
+
+    try {
+      expect(daemonArgv()).toEqual([
+        resolve('/usr/local/lib/node_modules/looptroop/dist/server/cli/cli.js'),
+        DAEMON_ARGV,
+      ])
+    } finally {
+      process.argv = argv
+    }
+  })
+
+  /**
+   * In a single-file build `argv[1]` is the executable rather than a script, so
+   * passing it along would run the binary against itself.
+   */
+  it('passes only the argument in a single-file build', () => {
+    seaMock.value = true
+    const argv = process.argv
+    process.argv = ['/usr/local/bin/looptroop', '/usr/local/bin/looptroop']
+
+    try {
+      expect(daemonArgv()).toEqual([DAEMON_ARGV])
+    } finally {
+      process.argv = argv
+    }
+  })
+
+  /** Whatever it is called and wherever it was installed. */
+  it('follows the entry script rather than assuming a file name', () => {
+    const argv = process.argv
+    process.argv = ['/usr/bin/node', '/opt/elsewhere/looptroop-cli.mjs']
+
+    try {
+      expect(daemonArgv()[0]).toBe(resolve('/opt/elsewhere/looptroop-cli.mjs'))
+    } finally {
+      process.argv = argv
+    }
+  })
+
+  it('refuses rather than spawning something meaningless when there is no entry script', () => {
+    const argv = process.argv
+    process.argv = ['/usr/bin/node']
+
+    try {
+      expect(() => daemonArgv()).toThrow(/no entry script/)
+    } finally {
+      process.argv = argv
+    }
+  })
+
+  /** Never a real command, and never printed in the usage text. */
+  it('uses an argument no user would type', () => {
+    expect(DAEMON_ARGV).toBe('__daemon')
+  })
+})

--- a/tests/daemonHandoff.test.ts
+++ b/tests/daemonHandoff.test.ts
@@ -15,14 +15,26 @@ import { resolve } from 'node:path'
 const seaMock = vi.hoisted(() => ({ value: false }))
 vi.mock('../server/lib/isSea', () => ({ isSea: () => seaMock.value }))
 
-const { DAEMON_ARGV, daemonArgv } = await import('../server/cli/daemonHandoff')
+/**
+ * Imported inside each test rather than once at the top.
+ *
+ * A single top-level import is evaluated before the first test runs, which
+ * makes the result depend on module-registry state this file does not control —
+ * it passed locally and failed on CI. Resetting and re-importing per test makes
+ * the mock's value at call time the only thing that decides the answer.
+ */
+async function load() {
+  vi.resetModules()
+  return import('../server/cli/daemonHandoff')
+}
 
 afterEach(() => {
   seaMock.value = false
 })
 
 describe('handing off to the daemon', () => {
-  it('names the entry script as well as the argument under npm', () => {
+  it('names the entry script as well as the argument under npm', async () => {
+    const { DAEMON_ARGV, daemonArgv } = await load()
     const argv = process.argv
     process.argv = ['/usr/bin/node', '/usr/local/lib/node_modules/looptroop/dist/server/cli/cli.js']
 
@@ -40,8 +52,9 @@ describe('handing off to the daemon', () => {
    * In a single-file build `argv[1]` is the executable rather than a script, so
    * passing it along would run the binary against itself.
    */
-  it('passes only the argument in a single-file build', () => {
+  it('passes only the argument in a single-file build', async () => {
     seaMock.value = true
+    const { DAEMON_ARGV, daemonArgv } = await load()
     const argv = process.argv
     process.argv = ['/usr/local/bin/looptroop', '/usr/local/bin/looptroop']
 
@@ -53,7 +66,8 @@ describe('handing off to the daemon', () => {
   })
 
   /** Whatever it is called and wherever it was installed. */
-  it('follows the entry script rather than assuming a file name', () => {
+  it('follows the entry script rather than assuming a file name', async () => {
+    const { daemonArgv } = await load()
     const argv = process.argv
     process.argv = ['/usr/bin/node', '/opt/elsewhere/looptroop-cli.mjs']
 
@@ -64,7 +78,8 @@ describe('handing off to the daemon', () => {
     }
   })
 
-  it('refuses rather than spawning something meaningless when there is no entry script', () => {
+  it('refuses rather than spawning something meaningless when there is no entry script', async () => {
+    const { daemonArgv } = await load()
     const argv = process.argv
     process.argv = ['/usr/bin/node']
 
@@ -76,7 +91,8 @@ describe('handing off to the daemon', () => {
   })
 
   /** Never a real command, and never printed in the usage text. */
-  it('uses an argument no user would type', () => {
+  it('uses an argument no user would type', async () => {
+    const { DAEMON_ARGV } = await load()
     expect(DAEMON_ARGV).toBe('__daemon')
   })
 })

--- a/tests/fixtures/channels/winget/LoopTroopAI.LoopTroop.installer.yaml
+++ b/tests/fixtures/channels/winget/LoopTroopAI.LoopTroop.installer.yaml
@@ -5,15 +5,14 @@ MinimumOSVersion: 10.0.17763.0
 InstallerType: zip
 NestedInstallerType: portable
 NestedInstallerFiles:
-  - RelativeFilePath: looptroop\bin\looptroop.cmd
+  - RelativeFilePath: looptroop-9.9.9-win-x64\looptroop.exe
     PortableCommandAlias: looptroop
 Dependencies:
   PackageDependencies:
-    - PackageIdentifier: OpenJS.NodeJS
     - PackageIdentifier: Git.Git
 Installers:
   - Architecture: neutral
-    InstallerUrl: https://github.com/looptroop-ai/LoopTroop/releases/download/v9.9.9/looptroop-9.9.9-bundle.zip
+    InstallerUrl: https://github.com/looptroop-ai/LoopTroop/releases/download/v9.9.9/looptroop-9.9.9-win-x64.zip
     InstallerSha256: 3C5FE4640000000000000000000000000000000000000000000000000000ABCD
 ManifestType: installer
 ManifestVersion: 1.6.0

--- a/tests/packageManifests.test.ts
+++ b/tests/packageManifests.test.ts
@@ -14,6 +14,7 @@ import {
   WINGET_IDENTIFIER,
   WINGET_MANIFEST_VERSION,
   wingetManifestDir,
+  windowsBinaryZipName,
   renderChocolateyInstall,
   renderChocolateyUninstall,
   renderDescriptor,
@@ -283,7 +284,7 @@ describe('where each descriptor lives', () => {
 describe('the WinGet manifests', () => {
   const WINGET_INPUTS = {
     version: '9.9.9',
-    url: 'https://github.com/looptroop-ai/LoopTroop/releases/download/v9.9.9/looptroop-9.9.9-bundle.zip',
+    url: 'https://github.com/looptroop-ai/LoopTroop/releases/download/v9.9.9/looptroop-9.9.9-win-x64.zip',
     sha256: '3c5fe4640000000000000000000000000000000000000000000000000000abcd',
   }
 
@@ -324,31 +325,34 @@ describe('the WinGet manifests', () => {
   })
 
   /**
-   * The dependency declaration is what lets this channel ship the ordinary
-   * bundle rather than waiting for a standalone binary: WinGet installs
-   * `PackageDependencies` by default. Without these two lines a clean Windows
-   * machine gets a package that cannot run.
+   * Only git. The binary carries its own Node runtime, so unlike the other
+   * three channels there is nothing to install for it — but `doctor` treats
+   * git as required and Windows does not ship one.
    */
-  it('declares Node and git, so a clean machine gets them', () => {
+  it('declares git, and does not ask for a Node it already contains', () => {
     const installer = rendered()[`${WINGET_IDENTIFIER}.installer.yaml`]!
-    expect(installer).toContain('PackageIdentifier: OpenJS.NodeJS')
     expect(installer).toContain('PackageIdentifier: Git.Git')
+    expect(installer).not.toContain('OpenJS.NodeJS')
   })
 
   /**
-   * The `.cmd`, never `bin/looptroop`: that one is a `#!` script, which Windows
-   * cannot execute. Scoop's `bin` points at the same file for the same reason.
+   * An `.exe`, and nothing else. `winget validate` refuses a portable whose
+   * `RelativeFilePath` is any other file type — it rejected the bundle's
+   * `.cmd` shim outright, which is why this channel installs the standalone
+   * binary rather than the bundle the other three take.
    */
-  it('shims the Windows wrapper rather than the shebang script', () => {
+  it('shims the standalone executable, which is the only type WinGet accepts', () => {
     const installer = rendered()[`${WINGET_IDENTIFIER}.installer.yaml`]!
-    expect(installer).toContain(`RelativeFilePath: ${BUNDLE_ROOT}\\bin\\looptroop.cmd`)
+    expect(installer).toMatch(/RelativeFilePath: .*\.exe$/m)
+    expect(installer).not.toContain('.cmd')
     expect(installer).toContain('PortableCommandAlias: looptroop')
     expect(installer).toContain('NestedInstallerType: portable')
   })
 
-  it('points at the ZIP, because WinGet cannot open a tarball', () => {
+  it('points at the Windows binary archive, not the bundle', () => {
     const installer = rendered()[`${WINGET_IDENTIFIER}.installer.yaml`]!
-    expect(installer).toContain(bundleZipFileName('9.9.9'))
+    expect(installer).toContain(windowsBinaryZipName('9.9.9'))
+    expect(installer).not.toContain(bundleZipFileName('9.9.9'))
     expect(installer).not.toContain(bundleFileName('9.9.9'))
     expect(installer).toContain('InstallerType: zip')
   })

--- a/tests/seaAssets.test.ts
+++ b/tests/seaAssets.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+/**
+ * Serving the built interface out of the executable.
+ *
+ * A single-file build has no `dist/client` beside it — no directory at all — so
+ * the walk that finds the interface in an npm install returns nothing and every
+ * page 404s while the API answers normally. That failure is invisible to
+ * anything except a request for an actual document.
+ */
+const sea = vi.hoisted(() => ({
+  isSea: false,
+  assets: new Map<string, string>(),
+}))
+
+vi.mock('../server/lib/isSea', () => ({ isSea: () => sea.isSea }))
+vi.mock('node:sea', () => ({
+  getAssetKeys: () => [...sea.assets.keys()],
+  getRawAsset: (key: string) => {
+    const value = sea.assets.get(key)
+    if (value === undefined) throw new Error(`no asset ${key}`)
+    return new TextEncoder().encode(value).buffer
+  },
+}))
+
+beforeEach(() => {
+  vi.resetModules()
+  sea.isSea = false
+  sea.assets = new Map()
+})
+
+async function load() {
+  return import('../server/lib/seaAssets')
+}
+
+function text(body: ArrayBuffer): string {
+  return new TextDecoder().decode(body)
+}
+
+describe('the embedded interface', () => {
+  it('reports none at all when this is not a single-file build', async () => {
+    sea.assets.set('client/index.html', '<!doctype html>')
+
+    const { hasEmbeddedClient, embeddedAsset } = await load()
+
+    expect(hasEmbeddedClient()).toBe(false)
+    expect(embeddedAsset('/index.html')).toBeNull()
+  })
+
+  it('reports none when the build carries no interface', async () => {
+    sea.isSea = true
+
+    expect((await load()).hasEmbeddedClient()).toBe(false)
+  })
+
+  it('serves a document and its hashed assets', async () => {
+    sea.isSea = true
+    sea.assets.set('client/index.html', '<!doctype html><script src="/assets/app-abc.js">')
+    sea.assets.set('client/assets/app-abc.js', 'export const x = 1')
+
+    const { hasEmbeddedClient, embeddedAsset } = await load()
+
+    expect(hasEmbeddedClient()).toBe(true)
+    expect(text(embeddedAsset('/index.html')!.body)).toContain('<!doctype html>')
+    expect(text(embeddedAsset('/assets/app-abc.js')!.body)).toBe('export const x = 1')
+  })
+
+  /**
+   * A wrong content type is not cosmetic: a browser refuses a module served as
+   * `application/octet-stream` and reports a MIME error rather than the real
+   * problem.
+   */
+  it.each([
+    ['/index.html', 'text/html; charset=utf-8'],
+    ['/assets/app-abc.js', 'text/javascript; charset=utf-8'],
+    ['/assets/app-abc.css', 'text/css; charset=utf-8'],
+    ['/assets/logo-abc.svg', 'image/svg+xml'],
+    ['/assets/font-abc.woff2', 'font/woff2'],
+    ['/assets/blob-abc.bin', 'application/octet-stream'],
+  ])('types %s as %s', async (path, expected) => {
+    sea.isSea = true
+    sea.assets.set(`client${path}`, 'x')
+
+    expect((await load()).embeddedAsset(path)!.contentType).toBe(expected)
+  })
+
+  it('has nothing for a path it does not carry', async () => {
+    sea.isSea = true
+    sea.assets.set('client/index.html', 'x')
+
+    expect((await load()).embeddedAsset('/assets/missing-abc.js')).toBeNull()
+  })
+
+  /**
+   * The key is looked up verbatim rather than resolved, so a traversal cannot
+   * name something outside the embedded tree: it either matches a key or it
+   * does not.
+   */
+  it('cannot be walked out of', async () => {
+    sea.isSea = true
+    sea.assets.set('client/index.html', 'x')
+    sea.assets.set('secret', 'do not serve me')
+
+    const { embeddedAsset } = await load()
+
+    expect(embeddedAsset('/../secret')).toBeNull()
+    expect(embeddedAsset('/..%2Fsecret')).toBeNull()
+  })
+
+  it('finds the document deep links fall back to', async () => {
+    sea.isSea = true
+    sea.assets.set('client/index.html', '<!doctype html>')
+
+    expect(text((await load()).embeddedIndex()!.body)).toBe('<!doctype html>')
+  })
+})

--- a/tests/updateCheck.test.ts
+++ b/tests/updateCheck.test.ts
@@ -47,6 +47,9 @@ describe('install channel detection', () => {
     // the other three it cannot leave a marker file. The path is the only
     // evidence, and WinGet owns this directory outright.
     ['/c/Users/u/AppData/Local/Microsoft/WinGet/Packages/LoopTroopAI.LoopTroop_Microsoft.Winget.Source_8wekyb3d8bbwe/looptroop/dist/server/cli', 'winget'],
+    // A portable is reached through the alias WinGet puts in `Links`, and the
+    // running executable resolves to that rather than to the unpacked copy.
+    ['/c/Users/u/AppData/Local/Microsoft/WinGet/Links', 'winget'],
   ])('detects %s as %s', (moduleDir, expected) => {
     expect(detectInstallChannel(moduleDir)).toBe(expected)
   })

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -234,8 +234,21 @@ export default defineConfig({
           sequence: { groupOrder: 0 },
           setupFiles: ['./server/test/setup.ts'],
           include: [...serverIntegrationTests],
-          testTimeout: 20000,
-          hookTimeout: 30000,
+          // Longer on Windows, and only there. These tests drive real git
+          // worktrees and real SQLite files, and the Windows runners do that
+          // several times slower than the other two — creating a worktree means
+          // thousands of individual file operations against a filesystem with
+          // far higher per-call overhead, made worse by Defender.
+          //
+          // This is not a retry and does not hide a race. Three separate runs
+          // on 2026-08-13 failed with *different* tests each time, every one at
+          // 25–28 s against a 20 s limit: the shape of work that is too slow,
+          // not work that is wrong. A retry would have hidden exactly that.
+          //
+          // Bounded rather than removed, so a genuine hang still fails the run
+          // instead of holding the job open until the 30-minute job timeout.
+          testTimeout: process.platform === 'win32' ? 45000 : 20000,
+          hookTimeout: process.platform === 'win32' ? 60000 : 30000,
           env: sharedEnv,
         },
       },


### PR DESCRIPTION
6B.0 and 6B.3 — the groundwork the standalone binaries need. **No binary is produced here**;
this removes the three things that would have made one impossible, and proves it by building
one throwaway.

## The spike: GO

A real single-file binary, driven from a temp directory with **no repo and no Node anywhere
on `PATH`**:

| check | result |
|---|---|
| `--version` | **0.5.1**, not `0.0.0` |
| `doctor --json` | works, reports the *embedded* runtime |
| **`start` detached → `status` → `stop`** | works |
| process gone after stop | confirmed |
| `GET /` | **200** `text/html`, from `sea.getAsset` |
| **every asset `index.html` references** | **39 / 39 → 200** |
| JS content-type + immutable cache | correct |
| missing `/assets/…` | **404 `text/plain`**, never HTML |
| SPA deep link | 200 HTML |
| `/api/health` | still routed |

The asset sweep is the point. A spike that fetched only `index.html` would have passed with
an interface that does not load.

## 1. `start` could never have worked from a single file

```js
spawn(process.execPath, [resolve(moduleDir(), 'daemonProcess.js')])
```

Under npm that is `node <dir>/daemonProcess.js` — fine, because npm unpacks a directory. In a
single-file build `process.execPath` **is** the executable and there is no second file, so it
re-invoked LoopTroop with a nonexistent path as its first argument; `start` would wait out
its readiness timeout and report a failure with no cause in the log.

One `__daemon` handler now serves both. `daemonArgv()` passes the entry script plus the
argument under npm, and the argument alone in a single-file build where `argv[1]` *is* the
executable. One start implementation, not two to keep in step.

## 2. `--version` would have printed `0.0.0`

Two callers resolved `package.json` three levels up from their own module. True for an npm
install, false everywhere else. `0.0.0` is the worst kind of failure — it still answers, and
it is silently wrong. Now compiled in, with the disk read kept for `tsx` and tests, and it
checks the manifest is *ours* so a bundle inside someone else's package cannot report their
version.

## 3. The interface had nowhere to come from

No `dist/client` beside the executable means every page 404s while the API answers normally.
Assets are embedded under `client/…` keys mirroring the built tree, so a request path maps to
a key by **lookup rather than resolution** — which is also why traversal is a non-question:
`/../secret` matches no key.

Caching follows the on-disk path exactly. Content types are set from the extension, because a
wrong one is not cosmetic: a browser refuses a module served as `application/octet-stream`
and reports a MIME error instead of the real problem.

**The on-disk branch is untouched**, and is only bypassed when the executable actually carries
an interface — so an npm install behaves exactly as before.

## Also: Windows integration timeouts, root-caused rather than retried

Three runs on 13 Aug failed with *different* tests each time, every one at **25–28 s against a
20 s limit**. That is the shape of work that is too slow, not work that is wrong — these tests
drive real git worktrees and SQLite, and Windows does that several times slower.

45 s on Windows only, **bounded** rather than removed so a genuine hang still fails. Deliberately
not `retry:`, which would have hidden the very signal — different tests, consistent duration —
that identified the cause.

## Checks

`lint`, `typecheck`, `verify:strip-types` pass. Full suite: **3251 passed, 2 skipped** (17 new).
Also driven by hand under npm: build → `start` detached → `status` reporting 0.5.1 → `stop` →
clean shutdown in the log.

🤖 Generated with [Claude Code](https://claude.com/claude-code)