### PR TITLE
docs: document WinGet and the standalone binaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ Unreleased changes appear first and represent commits that have not yet been inc
 
 > Changes merged since the last versioned release that have not yet shipped in a tagged version.
 
+### Summary
+- LoopTroop can now be installed with WinGet on Windows, and every release publishes a standalone executable for macOS on Apple silicon, Linux on x64 and arm64, and Windows on x64. The executable carries its own Node runtime, so it needs nothing installed but git — which is what makes the WinGet package work on a machine that has never had Node.
+- Each binary is built twice and required to be byte-identical before it is published, carries the licence of the Node runtime inside it, and comes with a build provenance attestation: a signed statement of which workflow, repository and commit produced those exact bytes.
+- `looptroop doctor` now recognises a WinGet install and a directly downloaded binary, and names the right upgrade command for each. On WinGet that command starts with `looptroop stop`, because Windows will not replace a running executable and the daemon holds it open.
+
 ### Fixed
 - Stopped the one-line installer reporting the wrong version when another copy of LoopTroop comes first on your PATH. It finished by running `looptroop --version` and printing whatever answered, which is a different copy whenever an older one is earlier in the search order — including when npm's global directory is not on the PATH at all, in which case it cheerfully reported a successful install of a version it had not touched. It now names the version it actually installed, and says so plainly when the command your shell will run is a different one.
 

--- a/README.md
+++ b/README.md
@@ -198,8 +198,14 @@ review gates.
 | **Homebrew** (macOS, Linux) | `brew install looptroop-ai/tap/looptroop` | `brew upgrade looptroop` |
 | **Scoop** (Windows) | `scoop bucket add looptroop https://github.com/looptroop-ai/scoop-bucket`<br>`scoop install looptroop` | `scoop update looptroop` |
 | **Chocolatey** (Windows) | `choco install looptroop` | `choco upgrade looptroop` |
+| **WinGet** (Windows) | `winget install LoopTroopAI.LoopTroop` | `looptroop stop`<br>`winget upgrade LoopTroopAI.LoopTroop` |
 | **npm** (everywhere) | `npm install -g looptroop` | `npm install -g looptroop@latest` |
 | **Docker** | `docker pull looptroopai/looptroop:latest` | `docker pull looptroopai/looptroop:latest` |
+
+WinGet arrives later than the others for the same reason Chocolatey does: every
+submission is a pull request reviewed by people at Microsoft. `looptroop stop`
+before upgrading is not optional there — Windows will not replace a running
+executable, and the daemon holds it open.
 
 `looptroop doctor` tells you which of these your copy came from and the exact
 command that upgrades it.
@@ -210,9 +216,22 @@ versions the release was tested against. Installing through npm resolves the
 version ranges afresh on your machine, which is how npm is supposed to work and
 is worth knowing when comparing two installations.
 
-Node is the one thing those three will install for you: LoopTroop is declared as
-depending on it, so Homebrew pulls in `node@24` and Scoop and Chocolatey pull in
-`nodejs-lts` if your machine has no suitable Node. That is the normal contract
+### Or download a binary
+
+Every release also publishes a standalone executable for macOS (Apple silicon),
+Linux (x64 and arm64) and Windows (x64), on the
+[releases page](https://github.com/looptroop-ai/LoopTroop/releases/latest). It
+carries its own Node runtime, so it needs nothing installed but git — which is
+what WinGet installs, and why that channel declares no Node dependency.
+
+Each archive is listed in the release's `release-manifest.json` with its
+checksum, and carries a build provenance attestation. Intel Macs are not among
+them: Node cannot build a single-file executable for that target, so use
+Homebrew or npm there.
+
+Node is the one thing the other three will install for you: LoopTroop is declared
+as depending on it, so Homebrew pulls in `node@24` and Scoop and Chocolatey pull
+in `nodejs-lts` if your machine has no suitable Node. That is the normal contract
 of a package manager, and it is the difference between them and the one-line
 installer above, which checks for Node, tells you what to do about it, and
 installs nothing itself.


### PR DESCRIPTION
The install table predated both. It listed four channels and a container, and said nothing
about the executable a release now publishes for four targets.

## Added

- A **WinGet** row, with `looptroop stop` in the upgrade cell.
- A **binary download** section: four targets, checksums in `release-manifest.json`,
  build provenance attestations.

## Two things stated rather than left to be discovered

- **`looptroop stop` before `winget upgrade` is not optional.** Windows will not replace a
  running executable and the daemon holds it open, so the upgrade fails for anyone actually
  using LoopTroop. `doctor` prints the same command.
- **Intel Macs are not among the binary targets.** Node cannot build a single-file executable
  for that target, so Homebrew and npm remain the way there.

Also notes that WinGet arrives later than the other channels for the same reason Chocolatey
does — every submission is a human-reviewed pull request.

## Changelog

Gains a `### Summary`, which is also what the release pipeline requires before 0.5.2 can be
cut. Verified with `npm run release:notes -- Unreleased`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)