### PR TITLE
test(opencode): remove the wall-clock race from the session-create timeout test

### DIFF
--- a/server/workflow/__tests__/runOpenCodePrompt.test.ts
+++ b/server/workflow/__tests__/runOpenCodePrompt.test.ts
@@ -865,22 +865,50 @@ describe('runOpenCodePrompt', () => {
     }
   })
 
+  /**
+   * Fake timers, because this asserts on where a 1ms deadline lands.
+   *
+   * With real timers it is a race the test loses roughly once in fifteen runs
+   * on a loaded machine: the retry loop checks `signal.aborted` *before* calling
+   * the adapter, so a deadline that fires during the several awaits it takes to
+   * get there produces zero session-create calls where this expects one. The
+   * failure reads as a product bug and is a wall-clock race in the test.
+   *
+   * Advancing deliberately also states what the test is actually about. The
+   * first attempt has to happen and fail on its own — none of that is
+   * timer-driven — and only then does the deadline land, inside the 1000ms wait
+   * before the second attempt. That is the state the name refers to.
+   */
   it('preserves timeout behavior while waiting to retry session creation', async () => {
-    const adapter = new TestOpenCodeAdapter(['assistant response'], {
-      createFailures: [
-        new Error('OpenCode returned no session payload'),
-      ],
-    })
+    vi.useFakeTimers()
+    try {
+      const adapter = new TestOpenCodeAdapter(['assistant response'], {
+        createFailures: [
+          new Error('OpenCode returned no session payload'),
+        ],
+      })
 
-    await expect(runOpenCodePrompt({
-      adapter,
-      projectPath: '/tmp/project',
-      parts: [{ type: 'text', content: 'Prompt body' }],
-      timeoutMs: 1,
-    })).rejects.toThrow('Timeout')
+      const runPromise = runOpenCodePrompt({
+        adapter,
+        projectPath: '/tmp/project',
+        parts: [{ type: 'text', content: 'Prompt body' }],
+        timeoutMs: 1,
+      })
+      const rejection = expect(runPromise).rejects.toThrow('Timeout')
 
-    expect(adapter.sessionCreateCalls).toHaveLength(1)
-    expect(adapter.promptCalls).toHaveLength(0)
+      await vi.advanceTimersByTimeAsync(0)
+      expect(adapter.sessionCreateCalls).toHaveLength(1)
+
+      await vi.advanceTimersByTimeAsync(1)
+      await rejection
+
+      // Still one: the deadline cut the wait short rather than allowing the
+      // retry the loop was about to make.
+      expect(adapter.sessionCreateCalls).toHaveLength(1)
+      expect(adapter.promptCalls).toHaveLength(0)
+    } finally {
+      vi.useRealTimers()
+    }
   })
 
   it('prompts a newly-created owned session without requiring it to appear in the remote session list first', async () => {


### PR DESCRIPTION
Found while checking a failure on PR #32's advisory Node 24 lane. Unrelated to that PR — a pre-existing race.

```
AssertionError: expected [] to have a length of 1 but got +0
 ❯ server/workflow/__tests__/runOpenCodePrompt.test.ts:882:40
```

## What was wrong

The test called `runOpenCodePrompt({ …, timeoutMs: 1 })` with **real timers** and then asserted exactly one session-create call had happened.

`createOpenCodeSessionWithRetry` checks `signal.aborted` *before* calling the adapter. A 1 ms deadline that fires during the several awaits it takes to reach that call means **zero** attempts — so the test fails claiming the code never tried, when the code never got the chance.

The assertion reads as a product bug and is a wall-clock race in the test.

## The fix

Fake timers, advanced deliberately, which also states what the test is actually about:

1. the first attempt happens and fails on its own — none of that is timer-driven
2. *then* the deadline lands, inside the 1000 ms wait before the second attempt

That second state is the one the test is named for, and it was previously reached by luck.

## Evidence

| | before | after |
|---|---|---|
| single test, 15 runs | 1 failure | — |
| single test, 30 runs | — | 0 failures |
| full file × 5, all 12 cores busy | — | 0 failures |

No retries added — the last commit to touch this file was `test(council): remove wall-clock races from deadline tests`, and this is the same class of defect it was fixing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)