### PR TITLE
fix(release): stop Windows cleanup failing a passing smoke, and cover machine-scope WinGet

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -478,10 +478,17 @@ function installGlobally(tarball) {
 
 const EXE = process.platform === 'win32' ? '.exe' : ''
 
-/** Removes something if it can, and never throws. A leftover is not a failure. */
+/**
+ * Removes something if it can, and never throws. A leftover is not a failure.
+ *
+ * Retried, because most of what this removes is an executable that was running
+ * moments ago and Windows does not release a handle the instant a process
+ * exits. `force` swallows ENOENT and nothing else, so without the retries a
+ * successful install could end by reporting EPERM.
+ */
 function discard(path) {
   try {
-    rmSync(path, { recursive: true, force: true })
+    rmSync(path, { recursive: true, force: true, maxRetries: 10, retryDelay: 100 })
     return true
   } catch {
     return false
@@ -885,7 +892,11 @@ async function main(argv) {
       installGlobally(tarballPath)
     }
   } finally {
-    rmSync(workDir, { recursive: true, force: true })
+    // Through `discard`, which retries and never throws. Failing to remove a
+    // temporary directory must not turn an install that worked into one that
+    // reports an error — and on Windows, after unpacking and running an
+    // executable, that is a real possibility rather than a theoretical one.
+    discard(workDir)
   }
 
   // Advisory only. `doctor` exits non-zero until OpenCode is set up, which is

--- a/install.sh
+++ b/install.sh
@@ -483,10 +483,17 @@ function installGlobally(tarball) {
 
 const EXE = process.platform === 'win32' ? '.exe' : ''
 
-/** Removes something if it can, and never throws. A leftover is not a failure. */
+/**
+ * Removes something if it can, and never throws. A leftover is not a failure.
+ *
+ * Retried, because most of what this removes is an executable that was running
+ * moments ago and Windows does not release a handle the instant a process
+ * exits. `force` swallows ENOENT and nothing else, so without the retries a
+ * successful install could end by reporting EPERM.
+ */
 function discard(path) {
   try {
-    rmSync(path, { recursive: true, force: true })
+    rmSync(path, { recursive: true, force: true, maxRetries: 10, retryDelay: 100 })
     return true
   } catch {
     return false
@@ -890,7 +897,11 @@ async function main(argv) {
       installGlobally(tarballPath)
     }
   } finally {
-    rmSync(workDir, { recursive: true, force: true })
+    // Through `discard`, which retries and never throws. Failing to remove a
+    // temporary directory must not turn an install that worked into one that
+    // reports an error — and on Windows, after unpacking and running an
+    // executable, that is a real possibility rather than a theoretical one.
+    discard(workDir)
   }
 
   // Advisory only. `doctor` exits non-zero until OpenCode is set up, which is

--- a/scripts/installer-core.mjs
+++ b/scripts/installer-core.mjs
@@ -428,10 +428,17 @@ function installGlobally(tarball) {
 
 const EXE = process.platform === 'win32' ? '.exe' : ''
 
-/** Removes something if it can, and never throws. A leftover is not a failure. */
+/**
+ * Removes something if it can, and never throws. A leftover is not a failure.
+ *
+ * Retried, because most of what this removes is an executable that was running
+ * moments ago and Windows does not release a handle the instant a process
+ * exits. `force` swallows ENOENT and nothing else, so without the retries a
+ * successful install could end by reporting EPERM.
+ */
 function discard(path) {
   try {
-    rmSync(path, { recursive: true, force: true })
+    rmSync(path, { recursive: true, force: true, maxRetries: 10, retryDelay: 100 })
     return true
   } catch {
     return false
@@ -835,7 +842,11 @@ async function main(argv) {
       installGlobally(tarballPath)
     }
   } finally {
-    rmSync(workDir, { recursive: true, force: true })
+    // Through `discard`, which retries and never throws. Failing to remove a
+    // temporary directory must not turn an install that worked into one that
+    // reports an error — and on Windows, after unpacking and running an
+    // executable, that is a real possibility rather than a theoretical one.
+    discard(workDir)
   }
 
   // Advisory only. `doctor` exits non-zero until OpenCode is set up, which is

--- a/scripts/smoke-binary-install.mjs
+++ b/scripts/smoke-binary-install.mjs
@@ -295,5 +295,13 @@ try {
   process.exitCode = 1
 } finally {
   server.close()
-  rmSync(work, { recursive: true, force: true })
+  // Retried, and never allowed to fail the run: this has just been running a
+  // Windows executable out of `work`, and Windows does not release the handle
+  // the instant the process exits. `force` swallows ENOENT and nothing else,
+  // so a plain removal turns a passing smoke into a failed release.
+  try {
+    rmSync(work, { recursive: true, force: true, maxRetries: 10, retryDelay: 100 })
+  } catch (error) {
+    process.stderr.write(`\nCould not remove ${work}: ${error.message}\n`)
+  }
 }

--- a/scripts/smoke-binary.mjs
+++ b/scripts/smoke-binary.mjs
@@ -191,5 +191,17 @@ async function main() {
 try {
   await main()
 } finally {
-  rmSync(work, { recursive: true, force: true })
+  // Retried, and never allowed to fail the run.
+  //
+  // Windows does not release a handle the instant a process exits, and this
+  // has just stopped a daemon that was running out of this directory. A plain
+  // `rmSync` there threw EPERM *after* the test had printed PASS — `force`
+  // swallows ENOENT and nothing else — so a passing smoke exited 1 and failed
+  // a release. `maxRetries` exists for exactly this; the catch is because a
+  // temp directory left behind is litter, not a failure.
+  try {
+    rmSync(work, { recursive: true, force: true, maxRetries: 10, retryDelay: 100 })
+  } catch (error) {
+    process.stderr.write(`\nCould not remove ${work}: ${error.message}\n`)
+  }
 }

--- a/scripts/smoke-winget.ts
+++ b/scripts/smoke-winget.ts
@@ -102,10 +102,29 @@ const server = createServer((request, response) => {
   createReadStream(archivePath).pipe(response)
 })
 
-/** Where WinGet puts the alias for a portable package. */
+/**
+ * Where WinGet puts the alias for a machine-scope portable package.
+ *
+ * Machine scope, not user scope, and the reason is the runner rather than a
+ * preference: CI runs elevated, and `winget uninstall` refuses outright to
+ * remove a user-scope package when it is running with administrator
+ * privileges —
+ *
+ *   Found LoopTroop [ARP\\User\\X64\\LoopTroopAI.LoopTroop__DefaultSource]
+ *   The package installed for user scope cannot be uninstalled when running
+ *   with administrator privileges.
+ *
+ * That left the job installing something it could not remove. Pinning the
+ * scope on both operations makes the two agree regardless of how the runner
+ * image happens to be configured, which is what changed under us.
+ *
+ * A real user installing unelevated still gets user scope; `installChannel`
+ * recognises both, which is a thing this change had to fix — the machine-scope
+ * path has no `Microsoft` in it.
+ */
 const linkPath = join(
-  process.env.LOCALAPPDATA ?? join(process.env.USERPROFILE ?? 'C:\\', 'AppData', 'Local'),
-  'Microsoft', 'WinGet', 'Links', 'looptroop.exe',
+  process.env.ProgramFiles ?? 'C:\\Program Files',
+  'WinGet', 'Links', 'looptroop.exe',
 )
 
 async function main(): Promise<void> {
@@ -134,6 +153,7 @@ async function main(): Promise<void> {
   log('Installing from the local manifest...')
   await invoke('winget', [
     'install', '--manifest', manifestDir,
+    '--scope', 'machine',
     '--accept-package-agreements', '--accept-source-agreements',
     '--disable-interactivity', '--skip-dependencies',
   ])
@@ -177,6 +197,7 @@ async function main(): Promise<void> {
   // which refuses to be queried until its agreements are accepted.
   await invoke('winget', [
     'uninstall', '--manifest', manifestDir,
+    '--scope', 'machine',
     '--accept-source-agreements', '--disable-interactivity',
   ])
 
@@ -202,5 +223,12 @@ try {
   process.exitCode = 1
 } finally {
   server.close()
-  rmSync(work, { recursive: true, force: true })
+  // Retried, and never allowed to fail the run — see `smoke-binary.mjs`:
+  // Windows holds handles briefly after a process exits, and `force` swallows
+  // only ENOENT, so cleanup can fail a smoke that has already passed.
+  try {
+    rmSync(work, { recursive: true, force: true, maxRetries: 10, retryDelay: 100 })
+  } catch (error) {
+    process.stderr.write(`\nCould not remove ${work}: ${String(error)}\n`)
+  }
 }

--- a/server/lib/installChannel.ts
+++ b/server/lib/installChannel.ts
@@ -130,7 +130,18 @@ function detectFromShape(moduleDir: string): InstallChannel {
   // than to the unpacked copy. Matching only `Packages` made a WinGet install
   // report itself as a plain downloaded binary — right about the artifact,
   // wrong about the upgrade command, which is the whole point of asking.
-  if (/\/Microsoft\/WinGet\//i.test(normalized)) return 'winget'
+  //
+  // Not `/Microsoft/WinGet/`, because only a *user*-scope install lives under
+  // `%LOCALAPPDATA%\Microsoft\WinGet`. A machine-scope one lives at
+  // `C:\Program Files\WinGet\Links`, with no `Microsoft` in the path at all —
+  // so the narrower pattern reported every machine-wide install as a plain
+  // downloaded binary, and gave those users the wrong upgrade command.
+  //
+  // Still anchored on the two directories WinGet owns rather than on the word
+  // alone: a checkout that merely sits inside a directory called `winget` —
+  // `winget-pkgs`, for one, which is exactly what somebody working on this
+  // package would have — must not be read as an install.
+  if (/\/WinGet\/(Links|Packages)(\/|$)/i.test(normalized)) return 'winget'
   if (/\/node_modules\/looptroop\//.test(normalized)) return 'npm'
 
   // A checkout has the sources a published package never ships.

--- a/tests/updateCheck.test.ts
+++ b/tests/updateCheck.test.ts
@@ -50,6 +50,12 @@ describe('install channel detection', () => {
     // A portable is reached through the alias WinGet puts in `Links`, and the
     // running executable resolves to that rather than to the unpacked copy.
     ['/c/Users/u/AppData/Local/Microsoft/WinGet/Links', 'winget'],
+    // Machine scope, which is a different path entirely: no `Microsoft` in it
+    // at all. Matching only the user-scope path reported every machine-wide
+    // install as a plain downloaded binary, and handed those users an upgrade
+    // command that would not upgrade anything.
+    ['/c/Program Files/WinGet/Links', 'winget'],
+    ['/c/Program Files/WinGet/Packages/LoopTroopAI.LoopTroop_Microsoft.Winget.Source_8wekyb3d8bbwe/looptroop/dist/server/cli', 'winget'],
   ])('detects %s as %s', (moduleDir, expected) => {
     expect(detectInstallChannel(moduleDir)).toBe(expected)
   })
@@ -65,6 +71,17 @@ describe('install channel detection', () => {
     '/home/linuxbrew/.linuxbrew/lib/node_modules/looptroop/dist/server/lib',
   ])('calls a global npm install under a brew prefix npm: %s', (moduleDir) => {
     expect(detectInstallChannel(moduleDir)).toBe('npm')
+  })
+
+  /**
+   * The matching risk that came with covering machine scope. Anchoring on the
+   * word `WinGet` alone would read a checkout that merely sits inside a
+   * directory of that name as an install — and `winget-pkgs` is exactly what
+   * somebody working on this package has checked out.
+   */
+  it('does not read a checkout beside the word winget as a WinGet install', () => {
+    expect(detectInstallChannel('/home/u/src/winget-pkgs/looptroop/dist/server/lib')).not.toBe('winget')
+    expect(detectInstallChannel('/home/u/WinGet/notes/looptroop/dist/server/lib')).not.toBe('winget')
   })
 
   it('detects a container from the build-time marker', () => {


### PR DESCRIPTION
Both found by **dry-running the release workflow**, which had never run with the Phase 6 jobs in it. CI proves the artifacts; the release DAG is different code.

## 1. Cleanup turned a passing smoke into a failed release

```
PASS: looptroop-0.5.2-win-x64.zip runs with no Node installed, serves its interface…
Error: EPERM, Permission denied: …\Temp\looptroop-binsmoke-bjpbEb
    at rmSync … smoke-binary.mjs:194
```

The test succeeded. Then its own `finally` killed the job — Windows had not released the just-stopped daemon's handle, and `force: true` swallows ENOENT and nothing else.

Because the binary matrix **gates `build`**, this failed the entire release: every downstream job skipped.

Fixed with `maxRetries`/`retryDelay`, which `rmSync` has for precisely this, plus a catch — a temp directory left behind is litter, not a failure. Same shape fixed in `smoke-binary-install.mjs`, `smoke-winget.ts`, and **`installer-core.mjs`, which ships to users**: a successful `--binary` install could have ended by reporting EPERM.

## 2. WinGet installed something the job could not uninstall

```
Found LoopTroop [ARP\User\X64\LoopTroopAI.LoopTroop__DefaultSource]
The package installed for user scope cannot be uninstalled when running with administrator privileges.
```

The runner is elevated; `winget uninstall` refuses a user-scope package outright in that state. The scope is now pinned on both operations so they agree however the runner image happens to be configured — which is what changed under us, since this passed an hour earlier on the same code.

### That exposed a real product bug

Only a **user**-scope install lives under `%LOCALAPPDATA%\Microsoft\WinGet`. A **machine**-scope one is at `C:\Program Files\WinGet\Links` — no `Microsoft` in the path at all.

So every machine-wide WinGet install reported itself as a plain downloaded binary and was handed an upgrade command that would not upgrade it. Detection now covers both, anchored on the two directories WinGet owns (`Links`, `Packages`) rather than the word alone — so a `winget-pkgs` checkout, which anyone working on this package has, is not read as an install. Both are tested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)