### PR TITLE
fix(phase-6): rollback restores the service, WinGet says x64, and a submitted manifest can be corrected

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,6 +45,18 @@ on:
         description: 'Build and verify without publishing anything'
         type: boolean
         default: true
+      # An escape hatch for a runner-class outage, not a convenience. The
+      # binaries are built on four native runners and they gate `build`, so if
+      # (say) macos-14 or ubuntu-24.04-arm is unavailable, nothing can be
+      # released at all — including a security fix. This releases without them,
+      # deliberately and visibly.
+      #
+      # Manual-only by construction: `workflow_dispatch` inputs are absent on a
+      # push, so the ordinary path cannot reach this even by accident.
+      skip_binaries:
+        description: 'Release without the standalone executables (runner outage only)'
+        type: boolean
+        default: false
 
 permissions:
   contents: read
@@ -76,6 +88,7 @@ jobs:
       version: ${{ steps.state.outputs.version }}
       state: ${{ steps.state.outputs.state }}
       dry_run: ${{ steps.guard.outputs.dry_run }}
+      skip_binaries: ${{ steps.guard.outputs.skip_binaries }}
       proceed: ${{ steps.state.outputs.proceed }}
       needs_npm: ${{ steps.state.outputs.needs_npm }}
       dist_tag: ${{ steps.state.outputs.dist_tag }}
@@ -107,6 +120,7 @@ jobs:
         id: guard
         env:
           REQUESTED: ${{ inputs.dry_run }}
+          SKIP_BINARIES: ${{ inputs.skip_binaries }}
         run: |
           set -euo pipefail
           if [ "${GITHUB_EVENT_NAME}" = "push" ] && [ "${GITHUB_REF}" = "refs/heads/main" ]; then
@@ -124,6 +138,16 @@ jobs:
           fi
           echo "dry_run=${dry_run}" >> "$GITHUB_OUTPUT"
           echo "Dry run: ${dry_run}"
+
+          # Normalised the same way and for the same reason: a boolean input
+          # arrives as the *string* "false", which is truthy in a GitHub
+          # expression.
+          skip_binaries=false
+          if [ "${GITHUB_EVENT_NAME}" = "workflow_dispatch" ] && [ "${SKIP_BINARIES:-}" = "true" ]; then
+            skip_binaries=true
+            echo "::warning::Releasing without the standalone executables, by operator request."
+          fi
+          echo "skip_binaries=${skip_binaries}" >> "$GITHUB_OUTPUT"
 
       # Classifies the release: skip, fresh, resume-npm, resume-github,
       # complete, unverified, or conflict. `skip` covers the ordinary case of a
@@ -213,7 +237,7 @@ jobs:
   binary:
     name: Binary (${{ matrix.target }})
     needs: [detect]
-    if: needs.detect.outputs.proceed == 'true'
+    if: needs.detect.outputs.proceed == 'true' && needs.detect.outputs.skip_binaries != 'true'
     runs-on: ${{ matrix.os }}
     timeout-minutes: 40
     permissions:
@@ -303,7 +327,15 @@ jobs:
   build:
     name: Build and pack
     needs: [detect, binary]
-    if: needs.detect.outputs.proceed == 'true'
+    # `always()` so a *deliberately* skipped matrix does not skip this too — and
+    # then an explicit check, because the default behaviour this replaces is the
+    # one that matters: a binary leg that *failed* must still stop the release
+    # rather than publish a version missing an architecture.
+    if: >-
+      always()
+      && needs.detect.outputs.proceed == 'true'
+      && (needs.binary.result == 'success'
+          || (needs.binary.result == 'skipped' && needs.detect.outputs.skip_binaries == 'true'))
     runs-on: ubuntu-latest
     timeout-minutes: 25
     outputs:
@@ -370,10 +402,35 @@ jobs:
       # `merge-multiple` because each target uploaded its own artefact and they
       # are all part of one release.
       - name: Collect the standalone binaries
+        if: needs.detect.outputs.skip_binaries != 'true'
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           pattern: release-binary-*
           merge-multiple: true
+
+      # All four or none, never a subset. The matrix is `fail-fast: false` so one
+      # target failing does not cancel the others, and `build` already refuses to
+      # run unless every leg succeeded — this is the belt to that braces, because
+      # publishing a release that is missing an architecture is invisible until
+      # somebody on that platform tries to install and gets a 404.
+      - name: Require every target's archive
+        if: needs.detect.outputs.skip_binaries != 'true'
+        run: |
+          set -euo pipefail
+          missing=""
+          for target in linux-x64 linux-arm64 darwin-arm64 win-x64; do
+            case "${target}" in
+              win-x64) name="looptroop-${{ needs.detect.outputs.version }}-${target}.zip" ;;
+              *) name="looptroop-${{ needs.detect.outputs.version }}-${target}.tar.gz" ;;
+            esac
+            [ -f "${name}" ] || missing="${missing} ${name}"
+          done
+          if [ -n "${missing}" ]; then
+            echo "::error::The binary matrix did not produce every archive:${missing}"
+            echo "::error::Release without them only by dispatching with skip_binaries=true."
+            exit 1
+          fi
+          echo "All four standalone archives are present."
 
       - name: Write the release manifest
         id: manifest
@@ -1745,6 +1802,7 @@ jobs:
         shell: bash
         env:
           WINGET_TOKEN: ${{ secrets.WINGET_TOKEN }}
+          SKIP_BINARIES: ${{ needs.detect.outputs.skip_binaries }}
           WIN_BINARY: ${{ steps.inputs.outputs.win_binary }}
           WIN_BINARY_URL: ${{ steps.inputs.outputs.win_binary_url }}
           WIN_BINARY_SHA256: ${{ steps.inputs.outputs.win_binary_sha256 }}
@@ -1757,6 +1815,15 @@ jobs:
             exit 0
           fi
           if [ -z "${WIN_BINARY}" ]; then
+            # WinGet is the one channel that installs the executable rather than
+            # the bundle, so with no executable there is nothing to publish. A
+            # release deliberately cut without the binaries skips this; anything
+            # else is a real problem and stays fatal.
+            if [ "${SKIP_BINARIES}" = "true" ]; then
+              echo "state=skipped" >> "$GITHUB_OUTPUT"
+              echo "::warning::No Windows binary in this release, so WinGet was skipped."
+              exit 0
+            fi
             echo "::error::This release carries no Windows binary, so WinGet cannot be published."
             exit 1
           fi
@@ -1846,6 +1913,7 @@ jobs:
       - publish-chocolatey
       - publish-winget
       - publish-aur
+      - binary
     if: always() && needs.detect.outputs.proceed == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 10
@@ -1878,6 +1946,8 @@ jobs:
           CHOCO_STATE: ${{ needs.publish-chocolatey.outputs.state }}
           R_WINGET: ${{ needs.publish-winget.result }}
           WINGET_STATE: ${{ needs.publish-winget.outputs.state }}
+          R_BINARY: ${{ needs.binary.result }}
+          SKIP_BINARIES: ${{ needs.detect.outputs.skip_binaries }}
           R_AUR: ${{ needs.publish-aur.result }}
           AUR_STATE: ${{ needs.publish-aur.outputs.state }}
           INDEX_DIGEST: ${{ needs.container-manifest.outputs.index_digest }}
@@ -1919,6 +1989,11 @@ jobs:
             printf 'chocolatey %s  %s\n' "${R_CHOCO}" "${CHOCO_STATE:-—}"
             printf 'winget     %s  %s\n' "${R_WINGET}" "${WINGET_STATE:-—}"
             printf 'aur        %s  %s\n' "${R_AUR}" "${AUR_STATE:-—}"
+            if [ "${SKIP_BINARIES}" = "true" ]; then
+              printf 'binaries   SKIPPED (operator)\n'
+            else
+              printf 'binaries   %s  (4 targets)\n' "${R_BINARY}"
+            fi
             echo '```'
             echo
             echo "Integrity: \`${INTEGRITY}\`"

--- a/install.ps1
+++ b/install.ps1
@@ -594,15 +594,35 @@ function stopDaemon(binary) {
   say('Stopping the running daemon...')
   spawnSync(binary, ['stop'], { stdio: 'inherit', timeout: 60_000 })
 
-  const deadline = Date.now() + 30_000
-  while (Date.now() < deadline) {
-    if (daemonRunning(binary) !== true) return true
+  return waitFor(() => daemonRunning(binary) !== true, 30_000)
+}
+
+/**
+ * Starts the daemon and waits until it is actually answering.
+ *
+ * The exit code of `start` is not the answer. It detaches, so it can report
+ * success and then die a second later — and this is called at the point where
+ * the difference decides whether an upgrade rolls back.
+ */
+function startDaemon(binary) {
+  spawnSync(binary, ['start'], { stdio: 'inherit', timeout: 120_000 })
+
+  // 30s: a daemon that is coming up answers in about two, so this is already
+  // an order of magnitude of headroom. Waiting longer would not rescue a build
+  // that is going to fail — it would only make every rollback slower to reach.
+  return waitFor(() => daemonRunning(binary) === true, 30_000)
+}
+
+/** Polls until `condition` holds, or gives up. */
+function waitFor(condition, timeoutMs) {
+  const deadline = Date.now() + timeoutMs
+  for (;;) {
+    if (condition()) return true
+    if (Date.now() >= deadline) return false
     // No timers: this is a synchronous stretch, and `Atomics.wait` is the one
     // sleep that does not need the event loop to turn.
     Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 500)
   }
-
-  return false
 }
 
 /**
@@ -715,25 +735,65 @@ function installBinary(archive, { version, prefix }) {
     // whole and still cannot start here — wrong architecture, a macOS signature
     // the kernel refuses, a missing glibc symbol — passes every earlier check
     // and fails at the only moment the user is watching.
-    const probe = spawnSync(installed, ['--version'], { encoding: 'utf8', timeout: 60_000 })
-    const reported = probe.status === 0 ? String(probe.stdout).trim() : null
-
-    if (reported !== version) {
+    /**
+     * Undoes the swap and puts the user back where they started — *including*
+     * the daemon.
+     *
+     * Restoring the executable is only half of it. This ran `stop` on a service
+     * that was up, so a rollback that restores the file and returns leaves the
+     * old version installed and not running, which is an outage caused by an
+     * upgrade that reported failure — the worst of both. The restart is
+     * therefore part of the rollback, and whether it worked is reported rather
+     * than assumed.
+     */
+    const rollBack = (reason, ...detail) => {
       const quarantine = `${installed}.rejected-${process.pid}`
       discard(quarantine)
       renameSync(installed, quarantine)
       if (replaced) renameSync(backup, installed)
 
+      const restored = replaced && wasRunning ? startDaemon(installed) : null
+
       fail(
+        reason,
+        ...detail,
+        replaced ? 'Your previous version is back in place.' : '',
+        restored === true ? 'It is running again.' : '',
+        restored === false
+          ? `It did not start again. Start it yourself with: ${installed} start`
+          : '',
+        `The rejected file is at ${quarantine} if you want to look at it.`,
+      )
+    }
+
+    const probe = spawnSync(installed, ['--version'], { encoding: 'utf8', timeout: 60_000 })
+    const reported = probe.status === 0 ? String(probe.stdout).trim() : null
+
+    if (reported !== version) {
+      rollBack(
         replaced
           ? `The new executable did not run, so ${version} was rolled back.`
           : 'The downloaded executable does not run here.',
         reported === null
           ? `\`looptroop --version\` exited ${String(probe.status ?? probe.signal)}: ${String(probe.stderr || probe.error?.message || '').trim().slice(0, 400)}`
           : `\`looptroop --version\` reported ${reported}, expected ${version}.`,
-        replaced ? 'Your previous version is back in place and working.' : '',
-        `The rejected file is at ${quarantine} if you want to look at it.`,
       )
+    }
+
+    // Restarted here rather than after this function returns, because here the
+    // backup still exists and the lock is still held. `--version` succeeding
+    // proves the file runs; it does not prove the daemon comes up, and those
+    // are different failures — a build that starts and immediately exits passes
+    // the first and fails the second. Confirming it before discarding the only
+    // copy of the working version is what makes this an upgrade you can undo.
+    if (wasRunning) {
+      say('Starting it again...')
+      if (!startDaemon(installed)) {
+        rollBack(
+          `${version} installed but its daemon would not start, so it was rolled back.`,
+          'The executable runs and reports the right version; it does not stay up.',
+        )
+      }
     }
 
     discard(backup)
@@ -813,17 +873,12 @@ async function main(argv) {
       await download(archiveAsset.browser_download_url, archivePath)
       verifyBytes(archivePath, digest)
 
+      // The daemon, if there was one, is already back up: `installBinary`
+      // restarts it before letting go of the backup, so that a daemon which
+      // will not start is a rollback rather than an outage.
       const { installed, wasRunning } = installBinary(archivePath, { version: intended, prefix })
       installedPath = installed
-      say(`Installed ${installed}`)
-
-      // Put back what the install took away. Somebody upgrading had a daemon
-      // running a moment ago, and leaving it stopped makes an upgrade into an
-      // outage they have to notice and fix themselves.
-      if (wasRunning) {
-        say('Starting it again...')
-        spawnSync(installed, ['start'], { stdio: 'inherit', timeout: 120_000 })
-      }
+      say(`Installed ${installed}${wasRunning ? ', and the daemon is running again' : ''}`)
 
       const bin = join(prefix, 'bin')
       pathAdvice = onPath(bin)

--- a/install.sh
+++ b/install.sh
@@ -599,15 +599,35 @@ function stopDaemon(binary) {
   say('Stopping the running daemon...')
   spawnSync(binary, ['stop'], { stdio: 'inherit', timeout: 60_000 })
 
-  const deadline = Date.now() + 30_000
-  while (Date.now() < deadline) {
-    if (daemonRunning(binary) !== true) return true
+  return waitFor(() => daemonRunning(binary) !== true, 30_000)
+}
+
+/**
+ * Starts the daemon and waits until it is actually answering.
+ *
+ * The exit code of `start` is not the answer. It detaches, so it can report
+ * success and then die a second later — and this is called at the point where
+ * the difference decides whether an upgrade rolls back.
+ */
+function startDaemon(binary) {
+  spawnSync(binary, ['start'], { stdio: 'inherit', timeout: 120_000 })
+
+  // 30s: a daemon that is coming up answers in about two, so this is already
+  // an order of magnitude of headroom. Waiting longer would not rescue a build
+  // that is going to fail — it would only make every rollback slower to reach.
+  return waitFor(() => daemonRunning(binary) === true, 30_000)
+}
+
+/** Polls until `condition` holds, or gives up. */
+function waitFor(condition, timeoutMs) {
+  const deadline = Date.now() + timeoutMs
+  for (;;) {
+    if (condition()) return true
+    if (Date.now() >= deadline) return false
     // No timers: this is a synchronous stretch, and `Atomics.wait` is the one
     // sleep that does not need the event loop to turn.
     Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 500)
   }
-
-  return false
 }
 
 /**
@@ -720,25 +740,65 @@ function installBinary(archive, { version, prefix }) {
     // whole and still cannot start here — wrong architecture, a macOS signature
     // the kernel refuses, a missing glibc symbol — passes every earlier check
     // and fails at the only moment the user is watching.
-    const probe = spawnSync(installed, ['--version'], { encoding: 'utf8', timeout: 60_000 })
-    const reported = probe.status === 0 ? String(probe.stdout).trim() : null
-
-    if (reported !== version) {
+    /**
+     * Undoes the swap and puts the user back where they started — *including*
+     * the daemon.
+     *
+     * Restoring the executable is only half of it. This ran `stop` on a service
+     * that was up, so a rollback that restores the file and returns leaves the
+     * old version installed and not running, which is an outage caused by an
+     * upgrade that reported failure — the worst of both. The restart is
+     * therefore part of the rollback, and whether it worked is reported rather
+     * than assumed.
+     */
+    const rollBack = (reason, ...detail) => {
       const quarantine = `${installed}.rejected-${process.pid}`
       discard(quarantine)
       renameSync(installed, quarantine)
       if (replaced) renameSync(backup, installed)
 
+      const restored = replaced && wasRunning ? startDaemon(installed) : null
+
       fail(
+        reason,
+        ...detail,
+        replaced ? 'Your previous version is back in place.' : '',
+        restored === true ? 'It is running again.' : '',
+        restored === false
+          ? `It did not start again. Start it yourself with: ${installed} start`
+          : '',
+        `The rejected file is at ${quarantine} if you want to look at it.`,
+      )
+    }
+
+    const probe = spawnSync(installed, ['--version'], { encoding: 'utf8', timeout: 60_000 })
+    const reported = probe.status === 0 ? String(probe.stdout).trim() : null
+
+    if (reported !== version) {
+      rollBack(
         replaced
           ? `The new executable did not run, so ${version} was rolled back.`
           : 'The downloaded executable does not run here.',
         reported === null
           ? `\`looptroop --version\` exited ${String(probe.status ?? probe.signal)}: ${String(probe.stderr || probe.error?.message || '').trim().slice(0, 400)}`
           : `\`looptroop --version\` reported ${reported}, expected ${version}.`,
-        replaced ? 'Your previous version is back in place and working.' : '',
-        `The rejected file is at ${quarantine} if you want to look at it.`,
       )
+    }
+
+    // Restarted here rather than after this function returns, because here the
+    // backup still exists and the lock is still held. `--version` succeeding
+    // proves the file runs; it does not prove the daemon comes up, and those
+    // are different failures — a build that starts and immediately exits passes
+    // the first and fails the second. Confirming it before discarding the only
+    // copy of the working version is what makes this an upgrade you can undo.
+    if (wasRunning) {
+      say('Starting it again...')
+      if (!startDaemon(installed)) {
+        rollBack(
+          `${version} installed but its daemon would not start, so it was rolled back.`,
+          'The executable runs and reports the right version; it does not stay up.',
+        )
+      }
     }
 
     discard(backup)
@@ -818,17 +878,12 @@ async function main(argv) {
       await download(archiveAsset.browser_download_url, archivePath)
       verifyBytes(archivePath, digest)
 
+      // The daemon, if there was one, is already back up: `installBinary`
+      // restarts it before letting go of the backup, so that a daemon which
+      // will not start is a rollback rather than an outage.
       const { installed, wasRunning } = installBinary(archivePath, { version: intended, prefix })
       installedPath = installed
-      say(`Installed ${installed}`)
-
-      // Put back what the install took away. Somebody upgrading had a daemon
-      // running a moment ago, and leaving it stopped makes an upgrade into an
-      // outage they have to notice and fix themselves.
-      if (wasRunning) {
-        say('Starting it again...')
-        spawnSync(installed, ['start'], { stdio: 'inherit', timeout: 120_000 })
-      }
+      say(`Installed ${installed}${wasRunning ? ', and the daemon is running again' : ''}`)
 
       const bin = join(prefix, 'bin')
       pathAdvice = onPath(bin)

--- a/scripts/installer-core.mjs
+++ b/scripts/installer-core.mjs
@@ -544,15 +544,35 @@ function stopDaemon(binary) {
   say('Stopping the running daemon...')
   spawnSync(binary, ['stop'], { stdio: 'inherit', timeout: 60_000 })
 
-  const deadline = Date.now() + 30_000
-  while (Date.now() < deadline) {
-    if (daemonRunning(binary) !== true) return true
+  return waitFor(() => daemonRunning(binary) !== true, 30_000)
+}
+
+/**
+ * Starts the daemon and waits until it is actually answering.
+ *
+ * The exit code of `start` is not the answer. It detaches, so it can report
+ * success and then die a second later — and this is called at the point where
+ * the difference decides whether an upgrade rolls back.
+ */
+function startDaemon(binary) {
+  spawnSync(binary, ['start'], { stdio: 'inherit', timeout: 120_000 })
+
+  // 30s: a daemon that is coming up answers in about two, so this is already
+  // an order of magnitude of headroom. Waiting longer would not rescue a build
+  // that is going to fail — it would only make every rollback slower to reach.
+  return waitFor(() => daemonRunning(binary) === true, 30_000)
+}
+
+/** Polls until `condition` holds, or gives up. */
+function waitFor(condition, timeoutMs) {
+  const deadline = Date.now() + timeoutMs
+  for (;;) {
+    if (condition()) return true
+    if (Date.now() >= deadline) return false
     // No timers: this is a synchronous stretch, and `Atomics.wait` is the one
     // sleep that does not need the event loop to turn.
     Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 500)
   }
-
-  return false
 }
 
 /**
@@ -665,25 +685,65 @@ function installBinary(archive, { version, prefix }) {
     // whole and still cannot start here — wrong architecture, a macOS signature
     // the kernel refuses, a missing glibc symbol — passes every earlier check
     // and fails at the only moment the user is watching.
-    const probe = spawnSync(installed, ['--version'], { encoding: 'utf8', timeout: 60_000 })
-    const reported = probe.status === 0 ? String(probe.stdout).trim() : null
-
-    if (reported !== version) {
+    /**
+     * Undoes the swap and puts the user back where they started — *including*
+     * the daemon.
+     *
+     * Restoring the executable is only half of it. This ran `stop` on a service
+     * that was up, so a rollback that restores the file and returns leaves the
+     * old version installed and not running, which is an outage caused by an
+     * upgrade that reported failure — the worst of both. The restart is
+     * therefore part of the rollback, and whether it worked is reported rather
+     * than assumed.
+     */
+    const rollBack = (reason, ...detail) => {
       const quarantine = `${installed}.rejected-${process.pid}`
       discard(quarantine)
       renameSync(installed, quarantine)
       if (replaced) renameSync(backup, installed)
 
+      const restored = replaced && wasRunning ? startDaemon(installed) : null
+
       fail(
+        reason,
+        ...detail,
+        replaced ? 'Your previous version is back in place.' : '',
+        restored === true ? 'It is running again.' : '',
+        restored === false
+          ? `It did not start again. Start it yourself with: ${installed} start`
+          : '',
+        `The rejected file is at ${quarantine} if you want to look at it.`,
+      )
+    }
+
+    const probe = spawnSync(installed, ['--version'], { encoding: 'utf8', timeout: 60_000 })
+    const reported = probe.status === 0 ? String(probe.stdout).trim() : null
+
+    if (reported !== version) {
+      rollBack(
         replaced
           ? `The new executable did not run, so ${version} was rolled back.`
           : 'The downloaded executable does not run here.',
         reported === null
           ? `\`looptroop --version\` exited ${String(probe.status ?? probe.signal)}: ${String(probe.stderr || probe.error?.message || '').trim().slice(0, 400)}`
           : `\`looptroop --version\` reported ${reported}, expected ${version}.`,
-        replaced ? 'Your previous version is back in place and working.' : '',
-        `The rejected file is at ${quarantine} if you want to look at it.`,
       )
+    }
+
+    // Restarted here rather than after this function returns, because here the
+    // backup still exists and the lock is still held. `--version` succeeding
+    // proves the file runs; it does not prove the daemon comes up, and those
+    // are different failures — a build that starts and immediately exits passes
+    // the first and fails the second. Confirming it before discarding the only
+    // copy of the working version is what makes this an upgrade you can undo.
+    if (wasRunning) {
+      say('Starting it again...')
+      if (!startDaemon(installed)) {
+        rollBack(
+          `${version} installed but its daemon would not start, so it was rolled back.`,
+          'The executable runs and reports the right version; it does not stay up.',
+        )
+      }
     }
 
     discard(backup)
@@ -763,17 +823,12 @@ async function main(argv) {
       await download(archiveAsset.browser_download_url, archivePath)
       verifyBytes(archivePath, digest)
 
+      // The daemon, if there was one, is already back up: `installBinary`
+      // restarts it before letting go of the backup, so that a daemon which
+      // will not start is a rollback rather than an outage.
       const { installed, wasRunning } = installBinary(archivePath, { version: intended, prefix })
       installedPath = installed
-      say(`Installed ${installed}`)
-
-      // Put back what the install took away. Somebody upgrading had a daemon
-      // running a moment ago, and leaving it stopped makes an upgrade into an
-      // outage they have to notice and fix themselves.
-      if (wasRunning) {
-        say('Starting it again...')
-        spawnSync(installed, ['start'], { stdio: 'inherit', timeout: 120_000 })
-      }
+      say(`Installed ${installed}${wasRunning ? ', and the daemon is running again' : ''}`)
 
       const bin = join(prefix, 'bin')
       pathAdvice = onPath(bin)

--- a/scripts/package-manifests.ts
+++ b/scripts/package-manifests.ts
@@ -254,6 +254,13 @@ export function wingetManifestDir(version: string): string {
  * unlike the Homebrew, Scoop and Chocolatey packages there is nothing to
  * install for it — but `doctor` still treats git as required and Windows does
  * not ship one.
+ *
+ * `Architecture: x64`, not `neutral`. The field describes the *installed
+ * binary*, not the archive that carries it, and this archive carries an x64
+ * executable and nothing else. `neutral` means the payload runs on any
+ * architecture, which would offer this package on Windows on ARM — a target
+ * `build-binary.mjs` deliberately does not build and `binaryTarget` refuses by
+ * name.
  */
 export function renderWingetManifests(inputs: ChannelInputs): Record<string, string> {
   assertInputs(inputs)
@@ -279,7 +286,7 @@ Dependencies:
   PackageDependencies:
     - PackageIdentifier: Git.Git
 Installers:
-  - Architecture: neutral
+  - Architecture: x64
     InstallerUrl: ${inputs.url}
     InstallerSha256: ${inputs.sha256.toUpperCase()}
 ManifestType: installer

--- a/scripts/winget-submit.ts
+++ b/scripts/winget-submit.ts
@@ -13,10 +13,16 @@
  * ## Retry-safe by construction
  *
  * A re-run of a release must not open a second pull request for the same
- * version. Before pushing, this looks for an open one from our fork for this
- * exact version and stops if it finds it. The branch name is derived from the
- * version too, so a re-push updates the same branch rather than accumulating
- * new ones.
+ * version — and must be able to *correct* the one that is open, which is a
+ * different thing. So this finds the open pull request for this version,
+ * re-renders the manifests, and pushes them to the same branch when they differ,
+ * leaving it alone when they do not. Walking away on sight of an open pull
+ * request, which is what this did first, made every correction to a submitted
+ * manifest unreachable: the `Architecture: neutral` error was found while
+ * #417030 was open and there was no way to deliver the fix.
+ *
+ * The branch name is derived from the version, so a re-push updates that branch
+ * rather than accumulating new ones.
  *
  * ## Why `git` and the API rather than wingetcreate
  *
@@ -60,7 +66,9 @@ const token = process.env.WINGET_TOKEN ?? fail('WINGET_TOKEN is not set.')
  * the pull request is opened against a repository we do not own, by a
  * credential that exists for exactly that purpose.
  */
-function run(command: string, args: string[], options: { cwd?: string, allowFailure?: boolean } = {}): string {
+function run(command: string, args: string[], options: { cwd?: string, allowFailure?: boolean, quiet?: true }): string
+function run(command: string, args: string[], options?: { cwd?: string, allowFailure?: boolean }): string
+function run(command: string, args: string[], options: { cwd?: string, allowFailure?: boolean, quiet?: true } = {}): string | null {
   try {
     return execFileSync(command, args, {
       cwd: options.cwd,
@@ -69,6 +77,9 @@ function run(command: string, args: string[], options: { cwd?: string, allowFail
       env: { ...process.env, GH_TOKEN: token },
     })
   } catch (error) {
+    // `quiet` distinguishes "this failed" from "this produced nothing", which
+    // matters for a probe whose whole answer is the exit code.
+    if (options.quiet === true) return null
     if (options.allowFailure === true) return ''
     const detail = error instanceof Error && 'stderr' in error ? String((error as { stderr?: unknown }).stderr ?? '') : ''
     fail(`${command} ${args.join(' ')} failed.`, detail)
@@ -76,6 +87,8 @@ function run(command: string, args: string[], options: { cwd?: string, allowFail
 }
 
 const version = flag('version')
+/** `manifests/l/LoopTroopAI/LoopTroop` — the package, without the version. */
+const identifierDir = wingetManifestDir(version).replace(/\/[^/]+$/, '')
 const url = flag('url')
 const sha256 = flag('sha256')
 
@@ -83,17 +96,18 @@ const branch = `looptroop-${version}`
 const work = mkdtempSync(join(tmpdir(), 'looptroop-winget-submit-'))
 
 try {
-  // Already open? A release re-run must reconcile rather than duplicate.
-  const existing = run('gh', [
+  // Already open? A release re-run must reconcile rather than duplicate — and
+  // reconcile means *bring it up to date*, not walk away. Exiting here on sight
+  // of an open pull request was wrong: it made every correction to a submitted
+  // manifest unreachable. The `Architecture: neutral` mistake was found while
+  // #417030 was open, and there was no way to push the fix to it.
+  const existing = JSON.parse(run('gh', [
     'pr', 'list', '--repo', UPSTREAM, '--state', 'open',
     '--head', `${FORK.split('/')[0]}:${branch}`, '--json', 'number,url',
-  ], { allowFailure: true }).trim()
+  ], { allowFailure: true }).trim() || '[]') as { number: number, url: string }[]
 
-  if (existing !== '' && existing !== '[]') {
-    log(`A pull request for ${version} is already open: ${existing}`)
-    log('Nothing to do; a re-run must not open a second one.')
-    process.exit(0)
-  }
+  const open = existing[0] ?? null
+  if (open !== null) log(`A pull request for ${version} is already open: ${open.url}`)
 
   // A shallow clone of the fork's default branch. The repository is enormous —
   // a full history would be gigabytes for a directory of three small files.
@@ -114,18 +128,63 @@ try {
   }
   log(`Wrote ${wingetManifestDir(version)}`)
 
+  /**
+   * `New package:` for the first submission of an identifier, `New version:`
+   * afterwards.
+   *
+   * The convention is upstream's, and their own labeller applies `New-Package`
+   * regardless of what we call it — which is how the mismatch showed up on
+   * #417030, titled `New version:` for a package that did not exist yet.
+   * Decided by asking whether the manifest directory exists on `upstream/master`
+   * rather than by remembering, so this is right on the first release and every
+   * one after it.
+   */
+  const alreadyPublished = run('git', ['cat-file', '-e', `upstream/master:${identifierDir}`], {
+    cwd: repo,
+    allowFailure: true,
+    quiet: true,
+  }) !== null
+  const title = `${alreadyPublished ? 'New version' : 'New package'}: ${WINGET_IDENTIFIER} version ${version}`
+
   run('git', ['config', 'user.name', 'looptroop-ai'], { cwd: repo })
   run('git', ['config', 'user.email', 'noreply@looptroop.ovh'], { cwd: repo })
   run('git', ['add', wingetManifestDir(version)], { cwd: repo })
-  run('git', ['commit', '-m', `New version: ${WINGET_IDENTIFIER} version ${version}`], { cwd: repo })
+
+  // Against the branch the open pull request is *actually* built on, not against
+  // `upstream/master` — this working tree was just reset onto master, where these
+  // files do not exist yet, so a staged diff there always reports a change and
+  // would never detect a no-op.
+  if (open !== null && run('git', ['fetch', 'origin', branch], { cwd: repo, quiet: true }) !== null) {
+    const unchanged = run('git', [
+      'diff', '--quiet', `origin/${branch}`, '--', wingetManifestDir(version),
+    ], { cwd: repo, quiet: true }) !== null
+
+    if (unchanged) {
+      log('The open pull request already carries exactly these manifests. Nothing to do.')
+      process.exit(0)
+    }
+    log('The manifests have changed; updating the pull request.')
+  }
+
+  run('git', ['commit', '-m', title], { cwd: repo })
   run('git', ['push', '--force-with-lease', 'origin', branch], { cwd: repo })
+
+  // An open pull request is updated by the push above; all that is left is to
+  // make its title right, since a first submission that was opened as
+  // `New version:` needs correcting in place.
+  if (open !== null) {
+    run('gh', ['pr', 'edit', String(open.number), '--repo', UPSTREAM, '--title', title], { allowFailure: true })
+    log(`\nUpdated ${open.url}`)
+    log('Acceptance is a review queue, not a result. Nothing waits on it.')
+    process.exit(0)
+  }
 
   const pr = run('gh', [
     'pr', 'create',
     '--repo', UPSTREAM,
     '--head', `${FORK.split('/')[0]}:${branch}`,
     '--base', 'master',
-    '--title', `New version: ${WINGET_IDENTIFIER} version ${version}`,
+    '--title', title,
     '--body', [
       `Adds ${WINGET_IDENTIFIER} ${version}.`,
       '',

--- a/server/cli/doctorCommand.ts
+++ b/server/cli/doctorCommand.ts
@@ -522,7 +522,11 @@ function checkInstallChannel(): Check {
         // A wrong upgrade command is worse than none, so this stays a warning.
         remedy: `${info.upgradeCommand}. To settle it, set "install": { "channel": "npm" } in ${getSettingsPath()}.`,
       }
-    : { name: 'install', status: 'ok', detail: `${info.channel} (upgrade: ${info.upgradeCommand})` }
+    : {
+        name: 'install',
+        status: 'ok',
+        detail: `${info.channel} (upgrade: ${info.upgradeFirst === undefined ? '' : `${info.upgradeFirst}, then `}${info.upgradeCommand})`,
+      }
 }
 
 /**

--- a/server/lib/installChannel.ts
+++ b/server/lib/installChannel.ts
@@ -10,6 +10,27 @@ export interface InstallInfo {
   channel: InstallChannel
   /** Exact command that upgrades this installation. */
   upgradeCommand: string
+  /**
+   * A command that must be run before `upgradeCommand`, where one is required.
+   *
+   * Kept separate rather than joined into one line, because no single joining
+   * operator works in both shells a Windows user might be in: `&&` is a
+   * PowerShell 7 operator and a parse error in the built-in PowerShell 5.1,
+   * while `;` chains in PowerShell and does not in `cmd.exe`. Two commands
+   * printed on two lines are correct everywhere.
+   */
+  upgradeFirst?: string
+}
+
+/**
+ * What has to happen before the upgrade command can work.
+ *
+ * Only WinGet has one: Windows refuses to replace a running executable, and
+ * the daemon holds this one open. The `--binary` installer stops the daemon
+ * itself, and the other channels replace files the daemon does not lock.
+ */
+const UPGRADE_PREREQUISITES: Partial<Record<InstallChannel, string>> = {
+  winget: 'looptroop stop',
 }
 
 const UPGRADE_COMMANDS: Record<InstallChannel, string> = {
@@ -17,9 +38,8 @@ const UPGRADE_COMMANDS: Record<InstallChannel, string> = {
   homebrew: 'brew upgrade looptroop',
   scoop: 'scoop update looptroop',
   chocolatey: 'choco upgrade looptroop',
-  // `looptroop stop` first, because Windows will not replace a running
-  // executable and the daemon holds this one open.
-  winget: 'looptroop stop && winget upgrade LoopTroopAI.LoopTroop',
+  // Preceded by `looptroop stop`; see UPGRADE_PREREQUISITES.
+  winget: 'winget upgrade LoopTroopAI.LoopTroop',
   // No single command exists here: pacman does not touch the AUR, and which
   // helper does is the user's choice. `yay` is the most widely installed, and
   // naming one that works beats a sentence that tells them nothing they did
@@ -173,7 +193,8 @@ export function detectInstallChannel(moduleDir = dirname(fileURLToPath(import.me
 
 export function getInstallInfo(moduleDir?: string): InstallInfo {
   const channel = detectInstallChannel(moduleDir)
-  return { channel, upgradeCommand: UPGRADE_COMMANDS[channel] }
+  const first = UPGRADE_PREREQUISITES[channel]
+  return { channel, upgradeCommand: UPGRADE_COMMANDS[channel], ...(first === undefined ? {} : { upgradeFirst: first }) }
 }
 
 /** The `install` object in `config.json`. */
@@ -214,7 +235,8 @@ export interface ResolveInstallOptions {
 }
 
 function info(channel: InstallChannel): InstallInfo {
-  return { channel, upgradeCommand: UPGRADE_COMMANDS[channel] }
+  const first = UPGRADE_PREREQUISITES[channel]
+  return { channel, upgradeCommand: UPGRADE_COMMANDS[channel], ...(first === undefined ? {} : { upgradeFirst: first }) }
 }
 
 function record(channel: InstallChannel, moduleDir: string, configDir?: string): void {

--- a/server/lib/updateCheck.ts
+++ b/server/lib/updateCheck.ts
@@ -30,6 +30,8 @@ export interface UpdateNotice {
   currentVersion: string
   latestVersion: string
   upgradeCommand: string
+  /** Run before `upgradeCommand`, where the channel needs it. */
+  upgradeFirst?: string
 }
 
 function getCachePath(configDir = resolveAppConfigDir()): string {
@@ -132,7 +134,10 @@ export async function checkForUpdate(options: CheckForUpdateOptions): Promise<Up
   return {
     currentVersion: options.currentVersion,
     latestVersion,
-    upgradeCommand: resolveInstallInfo({ ...(options.configDir ? { configDir: options.configDir } : {}) }).upgradeCommand,
+    ...(() => {
+      const info = resolveInstallInfo({ ...(options.configDir ? { configDir: options.configDir } : {}) })
+      return { upgradeCommand: info.upgradeCommand, ...(info.upgradeFirst === undefined ? {} : { upgradeFirst: info.upgradeFirst }) }
+    })(),
   }
 }
 
@@ -140,6 +145,9 @@ export function formatUpdateNotice(notice: UpdateNotice): string {
   return [
     '',
     `LoopTroop ${notice.latestVersion} is available (you have ${notice.currentVersion}).`,
+    // One command per line, each valid on its own. Joining them would need an
+    // operator, and none works in both `cmd.exe` and Windows PowerShell 5.1.
+    ...(notice.upgradeFirst === undefined ? [] : [`  ${notice.upgradeFirst}`]),
     `  ${notice.upgradeCommand}`,
     '',
   ].join('\n')

--- a/tests/fixtures/channels/winget/LoopTroopAI.LoopTroop.installer.yaml
+++ b/tests/fixtures/channels/winget/LoopTroopAI.LoopTroop.installer.yaml
@@ -11,7 +11,7 @@ Dependencies:
   PackageDependencies:
     - PackageIdentifier: Git.Git
 Installers:
-  - Architecture: neutral
+  - Architecture: x64
     InstallerUrl: https://github.com/looptroop-ai/LoopTroop/releases/download/v9.9.9/looptroop-9.9.9-win-x64.zip
     InstallerSha256: 3C5FE4640000000000000000000000000000000000000000000000000000ABCD
 ManifestType: installer

--- a/tests/installer.test.ts
+++ b/tests/installer.test.ts
@@ -571,6 +571,71 @@ describe('installer core', () => {
       expect(spawnSync(installed, ['--version'], { encoding: 'utf8' }).stdout.trim()).toBe('0.5.9')
     })
 
+    /**
+     * Restoring the executable is only half a rollback.
+     *
+     * The install stops a daemon that was up. Putting the old file back and
+     * returning leaves the previous version installed and *not running* — an
+     * outage caused by an upgrade that reported failure, which is the worst of
+     * both. It also used to say "back in place and working" while the service
+     * was down.
+     */
+    it.runIf(canInstallBinary)('restarts the daemon it stopped when it rolls back', async () => {
+      const prefix = freshPrefix()
+      const stubState = join(prefix, 'state')
+      const installed = join(prefix, 'bin', 'looptroop')
+
+      await runInstaller(['--binary', '--prefix', prefix], { LOOPTROOP_STUB_STATE: stubState })
+      writeFileSync(stubState, '')
+
+      archive = buildArchive('0.5.9', '#!/bin/sh\nexit 3\n')
+      const result = await runInstaller(['--binary', '--prefix', prefix], { LOOPTROOP_STUB_STATE: stubState })
+
+      expect(result.status).toBe(1)
+      expect(result.stderr).toContain('rolled back')
+      expect(result.stderr).toContain('It is running again.')
+      // The daemon it stopped is back, from the executable that still works.
+      expect(existsSync(stubState)).toBe(true)
+      expect(spawnSync(installed, ['--version'], { encoding: 'utf8' }).stdout.trim()).toBe('0.5.9')
+    })
+
+    /**
+     * `--version` succeeding does not prove the daemon comes up. A build that
+     * starts and immediately exits passes the first check and fails the second,
+     * and those are different failures — so the backup has to survive until the
+     * daemon is answering, not until the file runs once.
+     */
+    it.runIf(canInstallBinary)('rolls back a version that runs but whose daemon will not start', async () => {
+      const prefix = freshPrefix()
+      const stubState = join(prefix, 'state')
+      const installed = join(prefix, 'bin', 'looptroop')
+
+      await runInstaller(['--binary', '--prefix', prefix], { LOOPTROOP_STUB_STATE: stubState })
+      writeFileSync(stubState, '')
+
+      // Reports the right version, answers `status`, and `start` does nothing.
+      archive = buildArchive('0.5.9', [
+        '#!/bin/sh',
+        'case "$1" in',
+        '  --version) echo "0.5.9" ;;',
+        '  status) if [ -f "$LOOPTROOP_STUB_STATE" ]; then echo \'{"running":true}\'; else echo \'{"running":false}\'; fi ;;',
+        '  stop) rm -f "$LOOPTROOP_STUB_STATE"; echo "stub stopped" ;;',
+        '  start) echo "refusing to start" ;;',
+        'esac',
+        '',
+      ].join('\n'))
+
+      const result = await runInstaller(['--binary', '--prefix', prefix], { LOOPTROOP_STUB_STATE: stubState })
+
+      expect(result.status).toBe(1)
+      expect(result.stderr).toContain('would not start')
+      expect(result.stderr).toContain('It is running again.')
+      // Back on the version that works, and serving again: the state file only
+      // exists because the restored executable's `start` recreated it.
+      expect(existsSync(stubState)).toBe(true)
+      expect(spawnSync(installed, ['--version'], { encoding: 'utf8' }).stdout.trim()).toBe('0.5.9')
+    }, 120_000)
+
     it.runIf(canInstallBinary)('reports a first install that does not run, without claiming a rollback', async () => {
       archive = buildArchive('0.5.9', '#!/bin/sh\nexit 3\n')
       const result = await runInstaller(['--binary', '--prefix', freshPrefix()])

--- a/tests/packageManifests.test.ts
+++ b/tests/packageManifests.test.ts
@@ -375,6 +375,19 @@ describe('the WinGet manifests', () => {
     expect(() => renderWingetManifests({ ...WINGET_INPUTS, sha256: 'nope' })).toThrow()
   })
 
+  /**
+   * The field describes the installed binary, not the archive carrying it.
+   * `neutral` claims the payload runs anywhere, which would offer this package
+   * on Windows on ARM — a target `build-binary.mjs` does not build and
+   * `binaryTarget` refuses by name.
+   */
+  it('declares the architecture of the executable inside, not of the zip', () => {
+    const installer = rendered()[`${WINGET_IDENTIFIER}.installer.yaml`]!
+
+    expect(installer).toContain('Architecture: x64')
+    expect(installer).not.toContain('Architecture: neutral')
+  })
+
   /** The validation pipeline rejects a manifest filed anywhere else. */
   it('puts the manifests where winget-pkgs expects them', () => {
     expect(wingetManifestDir('9.9.9')).toBe('manifests/l/LoopTroopAI/LoopTroop/9.9.9')


### PR DESCRIPTION
A review round on Phase 6. **Five findings held up, three did not.**

## Confirmed and fixed

### 1. A failed upgrade left the daemon down — worst one

`installBinary` stops a running daemon. The rollback restored the executable and then threw, so `main()`'s restart never ran, and the message said *"Your previous version is back in place and working"* while the service was off. An upgrade that reports failure must not also cause an outage.

Worse: the backup was discarded **before** the restart. A build whose `--version` works but whose daemon won't stay up had nothing to roll back to — and those are different facts. The backup and the installer lock now survive until the daemon actually answers.

Two new tests: rollback while the daemon was running, and a binary that reports the right version but refuses to start.

### 2. `Architecture: neutral` for an x64-only `.exe`

The field describes the installed binary, not the archive. `neutral` offers the package on Windows on ARM — which `build-binary.mjs` doesn't build and `binaryTarget` refuses by name. Now `x64`, with a test and an updated golden file.

### 3. A submitted manifest could not be corrected

`winget-submit.ts` exited on sight of *any* open PR, so every correction was unreachable — the architecture error was found while #417030 was open with no way to deliver the fix. It now re-renders, compares against the branch the PR is actually built on (not `upstream/master`, which the working tree was just reset onto), and updates it; no-op only when the bytes already match.

It also titles a first submission `New package:`. Upstream's own labeller had tagged #417030 **`New-Package`** while our title said `New version:`.

### 4. `&&` is a parse error in Windows PowerShell 5.1

`looptroop stop && winget upgrade …` fails in the shell Windows still ships. No operator works in both PowerShell 5.1 and `cmd.exe`, so the prerequisite is its own field and prints on its own line — each line valid everywhere.

### 5. `skip_binaries` existed only in the plan

Four native runners gate `build`, so a runner-class outage could block a security release. Now a manual-only dispatch input that prints `binaries SKIPPED (operator)`. `build` additionally requires **all four archives or none** — never a subset.

## Refuted, with evidence

- **"`build` will ship a partial binary set."** It won't. `needs: [detect, binary]` with a plain `if:` skips it — demonstrated by the first dry run: `Binary (win-x64) failure` → `Build and pack skipped`.
- **"The Chocolatey API key is invalid/expired."** Chocolatey [documents 403](https://docs.chocolatey.org/en-us/community-repository/maintainers/common-errors/) for *"Package has a version in moderation and no approved versions"*. The same secret worked 8 hours earlier, 0.5.1 is still unapproved, and a direct key probe returned 200.
- **"6D Nix is not implemented."** Dropped by explicit decision.

## Needs a human, not code

**microsoft/winget-pkgs#417030 carries `Needs-CLA`.** Nothing merges until someone comments:

```
@microsoft-github-policy-service agree
```

Validation already passed (`Validation-Completed`, `Azure-Pipeline-Passed`), so the CLA is the only blocker. Once it's signed, re-dispatching `channel-republish.yml` for winget will push the `x64` correction to that same PR — which it could not do before this change.

Full suite: 3289 passed, 2 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)