### PR TITLE
fix(release): make the binary bypass usable, restart on every rollback path, and pause the blocked channels

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1859,8 +1859,9 @@ jobs:
   # None of them can currently complete, and a job that cannot succeed teaches
   # everyone to ignore a red release:
   #
-  #   PUBLISH_CHOCOLATEY  0.5.1 is still in moderation, and Chocolatey answers
-  #                       403 to a push for a package with no approved version.
+  #   PUBLISH_CHOCOLATEY  the first submission is still in moderation, and
+  #                       Chocolatey answers 403 to a push for a package that
+  #                       has no approved version yet.
   #   PUBLISH_WINGET      every submission is a pull request reviewed by people
   #                       at Microsoft, and the first one also needs a CLA.
   #   PUBLISH_AUR         registration is closed upstream after a security

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -125,6 +125,19 @@ jobs:
           set -euo pipefail
           if [ "${GITHUB_EVENT_NAME}" = "push" ] && [ "${GITHUB_REF}" = "refs/heads/main" ]; then
             dry_run=false
+          elif [ "${GITHUB_EVENT_NAME}" = "workflow_dispatch" ] \
+            && [ "${GITHUB_REF}" = "refs/heads/main" ] \
+            && [ "${REQUESTED}" = "false" ] \
+            && [ "${SKIP_BINARIES:-}" = "true" ]; then
+            # The one manual route that publishes, and it exists solely for a
+            # runner-class outage: every other dispatch is forced to a dry run,
+            # which is what made `skip_binaries` unusable — the input could be
+            # set but the release it was meant to rescue could never happen.
+            #
+            # Narrow on purpose: the exact `main` ref, an explicit `dry_run=false`,
+            # and `skip_binaries=true` together. Anything less is still a dry run.
+            dry_run=false
+            echo "::warning::Publishing from a manual dispatch, because skip_binaries was requested."
           else
             dry_run=true
             if [ "${REQUESTED}" = "false" ]; then
@@ -434,6 +447,8 @@ jobs:
 
       - name: Write the release manifest
         id: manifest
+        env:
+          SKIP_BINARIES: ${{ needs.detect.outputs.skip_binaries }}
         run: |
           set -euo pipefail
           tarball="looptroop-${{ needs.detect.outputs.version }}.tgz"
@@ -450,9 +465,12 @@ jobs:
           while IFS= read -r file; do binaries+=(--asset "${file}"); done < <(
             find . -maxdepth 1 \( -name 'looptroop-*-linux-*.tar.gz' -o -name 'looptroop-*-darwin-*.tar.gz' -o -name 'looptroop-*-win-*.zip' \) | sort
           )
-          if [ "${#binaries[@]}" -eq 0 ]; then
+          if [ "${#binaries[@]}" -eq 0 ] && [ "${SKIP_BINARIES}" != "true" ]; then
             echo "::error::No standalone binaries were collected; the manifest would omit them."
             exit 1
+          fi
+          if [ "${#binaries[@]}" -eq 0 ]; then
+            echo "::warning::Writing a manifest with no standalone binaries, by operator request."
           fi
           npm run release:manifest -- "${tarball}" \
             --asset "${bundle}" --asset "${zip}" --asset install.sh --asset install.ps1 \
@@ -1690,6 +1708,7 @@ jobs:
       needs.detect.outputs.proceed == 'true'
       && needs.detect.outputs.dry_run == 'false'
       && needs.detect.outputs.dist_tag == 'latest'
+      && vars.PUBLISH_CHOCOLATEY == 'true'
     runs-on: windows-latest
     timeout-minutes: 30
     environment: packaging
@@ -1771,6 +1790,7 @@ jobs:
       needs.detect.outputs.proceed == 'true'
       && needs.detect.outputs.dry_run == 'false'
       && needs.detect.outputs.dist_tag == 'latest'
+      && vars.PUBLISH_WINGET == 'true'
     runs-on: windows-latest
     timeout-minutes: 30
     environment: packaging
@@ -1833,6 +1853,23 @@ jobs:
             --sha256 "${WIN_BINARY_SHA256}"
           echo "state=submitted" >> "$GITHUB_OUTPUT"
 
+  # ---------------------------------------------------------------------------
+  # Three channels are paused, each behind a repository variable that is unset.
+  #
+  # None of them can currently complete, and a job that cannot succeed teaches
+  # everyone to ignore a red release:
+  #
+  #   PUBLISH_CHOCOLATEY  0.5.1 is still in moderation, and Chocolatey answers
+  #                       403 to a push for a package with no approved version.
+  #   PUBLISH_WINGET      every submission is a pull request reviewed by people
+  #                       at Microsoft, and the first one also needs a CLA.
+  #   PUBLISH_AUR         registration is closed upstream after a security
+  #                       incident, so there is no account to publish from.
+  #
+  # Re-enable one with:  gh variable set PUBLISH_WINGET --body true
+  # `tmp/check-channels.mjs` reports when each becomes possible again.
+  # ---------------------------------------------------------------------------
+
   # Dormant until the AUR reopens registration. It skips rather than fails when
   # `AUR_SSH_KEY` is empty, because a channel nobody can publish to must not be
   # able to fail a release — the same bargain the WinGet job makes.
@@ -1843,6 +1880,7 @@ jobs:
       needs.detect.outputs.proceed == 'true'
       && needs.detect.outputs.dry_run == 'false'
       && needs.detect.outputs.dist_tag == 'latest'
+      && vars.PUBLISH_AUR == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 20
     environment: packaging
@@ -2004,6 +2042,12 @@ jobs:
           } > /tmp/report.md
           cat /tmp/report.md >> "$GITHUB_STEP_SUMMARY"
 
+          # A deliberate skip is not a failure; anything else about the binary
+          # matrix is, and printing it in the table without listing it here meant
+          # a failed target never opened the issue.
+          BINARY_FOR_ISSUE="${R_BINARY}"
+          if [ "${SKIP_BINARIES}" = "true" ]; then BINARY_FOR_ISSUE=success; fi
+
           failed=""
           for pair in "build:${R_BUILD}" "verify-artifact:${R_VERIFY}" \
                       "verify-readonly:${R_READONLY}" "draft-release:${R_DRAFT}" \
@@ -2013,7 +2057,8 @@ jobs:
                       "publish-homebrew:${R_BREW}" "publish-scoop:${R_SCOOP}" \
                       "publish-chocolatey:${R_CHOCO}" \
                       "publish-winget:${R_WINGET}" \
-                      "publish-aur:${R_AUR}"; do
+                      "publish-aur:${R_AUR}" \
+                      "binary:${BINARY_FOR_ISSUE}"; do
             name=${pair%%:*}
             result=${pair#*:}
             case "${result}" in

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,21 @@ Unreleased changes appear first and represent commits that have not yet been inc
 
 > Changes merged since the last versioned release that have not yet shipped in a tagged version.
 
+### Summary
+- Fixed an upgrade of the standalone executable that could leave LoopTroop stopped. If replacing the file failed, or the new version would not run, the old one was put back — but the daemon that had been stopped first was never started again, and the message said it was "back in place and working". Every path that stops the daemon now starts it again and says whether that worked.
+- Corrected the WinGet package to declare `x64` rather than `neutral`. `neutral` means "runs on any architecture", which would have offered an Intel-only executable to Windows on ARM, where it is not built.
+- Paused publishing to Chocolatey, WinGet and the AUR. None of the three can currently complete — a moderation queue, a review queue, and a registration that is closed upstream — and a release job that cannot succeed teaches everyone to ignore a failed release. Each is one repository variable away from being switched back on.
+
+### Fixed
+- An upgrade to the standalone executable could stop LoopTroop and not start it again. The `--binary` installer stops a running daemon before replacing the file; if the replacement failed or the new executable did not run, it restored the previous version and stopped there, leaving the service down while reporting that the previous version was "back in place and working". All three failure paths now restart what they stopped, and report whether it came back.
+- The standalone upgrade also discarded its only copy of the working version before confirming the new one could serve. An executable that reports the right version and then exits on start passes the first check and fails the second; the backup now survives until the daemon answers.
+- `looptroop doctor` told WinGet users to run `looptroop stop && winget upgrade …`, which is a syntax error in the PowerShell that Windows ships. The two commands are now printed on separate lines, each valid in every Windows shell.
+- The WinGet package declared `Architecture: neutral` for an archive containing only an x64 executable.
+- A failed standalone-binary build was shown in the release report but never opened the release-failure issue.
+
+### Changed
+- Publishing to Chocolatey, WinGet and the AUR is switched off until each becomes possible again. `tmp/check-channels.mjs` reports when that is.
+
 ## 0.5.2 (2026-08-13)
 
 

--- a/install.ps1
+++ b/install.ps1
@@ -720,6 +720,13 @@ function installBinary(archive, { version, prefix }) {
     try {
       replaced = swapIntoPlace(staged, installed, backup)
     } catch (error) {
+      // `swapIntoPlace` already put the old executable back, but the daemon was
+      // stopped before it ran — so leaving here without starting it again is the
+      // same outage the rollback path exists to prevent, reached by a different
+      // route. Windows makes this the *likeliest* route, not a remote one: it is
+      // where a locked file lands.
+      const restored = wasRunning ? startDaemon(installed) : null
+
       fail(
         `Could not replace ${installed}.`,
         String(error.message ?? error),
@@ -727,6 +734,10 @@ function installBinary(archive, { version, prefix }) {
           ? 'On Windows a running program cannot be replaced; check nothing else is using it.'
           : '',
         'Nothing was installed; the previous version is untouched.',
+        restored === true ? 'Its daemon is running again.' : '',
+        restored === false
+          ? `Its daemon did not start again. Start it with: ${installed} start`
+          : '',
       )
     }
 

--- a/install.sh
+++ b/install.sh
@@ -725,6 +725,13 @@ function installBinary(archive, { version, prefix }) {
     try {
       replaced = swapIntoPlace(staged, installed, backup)
     } catch (error) {
+      // `swapIntoPlace` already put the old executable back, but the daemon was
+      // stopped before it ran — so leaving here without starting it again is the
+      // same outage the rollback path exists to prevent, reached by a different
+      // route. Windows makes this the *likeliest* route, not a remote one: it is
+      // where a locked file lands.
+      const restored = wasRunning ? startDaemon(installed) : null
+
       fail(
         `Could not replace ${installed}.`,
         String(error.message ?? error),
@@ -732,6 +739,10 @@ function installBinary(archive, { version, prefix }) {
           ? 'On Windows a running program cannot be replaced; check nothing else is using it.'
           : '',
         'Nothing was installed; the previous version is untouched.',
+        restored === true ? 'Its daemon is running again.' : '',
+        restored === false
+          ? `Its daemon did not start again. Start it with: ${installed} start`
+          : '',
       )
     }
 

--- a/scripts/installer-core.mjs
+++ b/scripts/installer-core.mjs
@@ -670,6 +670,13 @@ function installBinary(archive, { version, prefix }) {
     try {
       replaced = swapIntoPlace(staged, installed, backup)
     } catch (error) {
+      // `swapIntoPlace` already put the old executable back, but the daemon was
+      // stopped before it ran — so leaving here without starting it again is the
+      // same outage the rollback path exists to prevent, reached by a different
+      // route. Windows makes this the *likeliest* route, not a remote one: it is
+      // where a locked file lands.
+      const restored = wasRunning ? startDaemon(installed) : null
+
       fail(
         `Could not replace ${installed}.`,
         String(error.message ?? error),
@@ -677,6 +684,10 @@ function installBinary(archive, { version, prefix }) {
           ? 'On Windows a running program cannot be replaced; check nothing else is using it.'
           : '',
         'Nothing was installed; the previous version is untouched.',
+        restored === true ? 'Its daemon is running again.' : '',
+        restored === false
+          ? `Its daemon did not start again. Start it with: ${installed} start`
+          : '',
       )
     }
 


### PR DESCRIPTION
Second review round — **all five findings held up.**

## 1. `skip_binaries` could never have worked

Two independent blockers, either fatal:

- **Every manual dispatch was forced to a dry run.** The input could be set, but the release it exists to rescue could never happen.
- **The manifest step refused to write without binaries** — `exit 1` on zero archives.

So the escape hatch added last round was decorative. There is now exactly one manual publishing route: the exact `main` ref, `dry_run=false` **and** `skip_binaries=true` together. Anything less is still a dry run. The manifest tolerates zero binaries only in that mode, and warns.

## 2. A third rollback path still left the daemon down

Last round fixed the version-mismatch and start-failure paths. The **swap-error** path still exited without restarting — and on Windows that's the *likeliest* one, because it's where a locked file lands. Now every path that stops the daemon starts it again and reports whether it came back.

## 3. A failed binary leg never opened the failure issue

It was printed in the report table and omitted from the list that decides whether to raise one — so a target could fail silently as far as anyone not watching the run was concerned. A deliberate `skip_binaries` still doesn't count as a failure.

## 4. The plan claimed these shipped in 0.5.2

False — 0.5.2 was cut before them. Corrected, and the changelog now records them under Unreleased. **These need a 0.5.3.**

## 5. WinGet PR #417030 — fixed directly

It still carried `Architecture: neutral`, and `channel-republish.yml` deliberately checks out the *release's* commit, so it would have re-rendered the old value. I pushed the correction to the fork branch by hand instead:

- `Architecture: x64`
- retitled `New package: LoopTroopAI.LoopTroop version 0.5.2`
- `Needs-CLA` is **gone** — the CLA signature took effect

## Also: the three blocked channels are paused

Chocolatey, WinGet and AUR publishing are each behind an unset repository variable. None can currently complete — a moderation queue, a review queue, a closed registration — and a job that cannot succeed teaches everyone to ignore a red release.

```bash
gh variable set PUBLISH_WINGET --body true --repo looptroop-ai/LoopTroop
```

`tmp/check-channels.mjs` reports when each becomes possible, and prints that command when it does. It deliberately does **not** guess whether AUR registration reopened: that page renders its form in JavaScript and answers 200 either way, so any heuristic would report a confident wrong answer forever.

🤖 Generated with [Claude Code](https://claude.com/claude-code)