### PR TITLE
release: v0.5.3

### DIFF
--- a/.github/releases/0.5.3.md
+++ b/.github/releases/0.5.3.md
@@ -1,0 +1,17 @@
+## 0.5.3 (2026-08-14)
+
+
+### Summary
+- Fixed an upgrade of the standalone executable that could leave LoopTroop stopped. If replacing the file failed, or the new version would not run, the old one was put back — but the daemon that had been stopped first was never started again, and the message said it was "back in place and working". Every path that stops the daemon now starts it again and says whether that worked.
+- Corrected the WinGet package to declare `x64` rather than `neutral`. `neutral` means "runs on any architecture", which would have offered an Intel-only executable to Windows on ARM, where it is not built.
+- Paused publishing to Chocolatey, WinGet and the AUR. None of the three can currently complete — a moderation queue, a review queue, and a registration that is closed upstream — and a release job that cannot succeed teaches everyone to ignore a failed release. Each is one repository variable away from being switched back on.
+
+### Fixed
+- An upgrade to the standalone executable could stop LoopTroop and not start it again. The `--binary` installer stops a running daemon before replacing the file; if the replacement failed or the new executable did not run, it restored the previous version and stopped there, leaving the service down while reporting that the previous version was "back in place and working". All three failure paths now restart what they stopped, and report whether it came back.
+- The standalone upgrade also discarded its only copy of the working version before confirming the new one could serve. An executable that reports the right version and then exits on start passes the first check and fails the second; the backup now survives until the daemon answers.
+- `looptroop doctor` told WinGet users to run `looptroop stop && winget upgrade …`, which is a syntax error in the PowerShell that Windows ships. The two commands are now printed on separate lines, each valid in every Windows shell.
+- The WinGet package declared `Architecture: neutral` for an archive containing only an x64 executable.
+- A failed standalone-binary build was shown in the release report but never opened the release-failure issue.
+
+### Changed
+- Publishing to Chocolatey, WinGet and the AUR is switched off until each becomes possible again.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ Unreleased changes appear first and represent commits that have not yet been inc
 
 > Changes merged since the last versioned release that have not yet shipped in a tagged version.
 
+## 0.5.3 (2026-08-14)
+
+
 ### Summary
 - Fixed an upgrade of the standalone executable that could leave LoopTroop stopped. If replacing the file failed, or the new version would not run, the old one was put back — but the daemon that had been stopped first was never started again, and the message said it was "back in place and working". Every path that stops the daemon now starts it again and says whether that worked.
 - Corrected the WinGet package to declare `x64` rather than `neutral`. `neutral` means "runs on any architecture", which would have offered an Intel-only executable to Windows on ARM, where it is not built.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "looptroop",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "looptroop",
-      "version": "0.5.2",
+      "version": "0.5.3",
       "license": "MIT",
       "dependencies": {
         "@hono/node-server": "^2.0.12",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "looptroop",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "description": "Local AI coding orchestration for repo-scale work: LLM-council planning, Ralph-loop recovery, isolated OpenCode worktrees, and human-gated PR delivery.",
   "type": "module",
   "keywords": [


### PR DESCRIPTION
**Merging this publishes.** npm, GitHub, Docker Hub and GHCR, Homebrew, Scoop. Chocolatey, WinGet and the AUR skip — each is paused behind an unset repository variable because none can currently complete.

## What ships

Fixes that landed after 0.5.2 was cut:

- **An upgrade of the standalone executable could leave LoopTroop stopped.** All three failure paths — the replacement throwing, the new executable not running, and its daemon not staying up — now restart what they stopped and say whether it came back. The backup survives until the daemon answers, because `--version` succeeding and the service coming up are different facts.
- **The WinGet package declares `x64`, not `neutral`** — `neutral` would have offered an x64-only executable on Windows on ARM.
- **`looptroop doctor` no longer prints an upgrade command that PowerShell 5.1 rejects** (`&&` is a PowerShell 7 operator).
- **`skip_binaries` actually works.** It could never publish before: every manual dispatch was forced to a dry run, and the manifest refused to be written without binaries.
- **A failed binary leg now opens the release-failure issue** instead of only appearing in the report.

## Verified before proposing it

Dry-run from this branch, green through the whole DAG, publishing nothing:

```
Detect release state        success
Binary × 4 targets          success
Build and pack              success
Verify artefact × 3 OSes    success
Draft the GitHub release    success
publish-*                   skipped
```

That run was also the first real exercise of `scripts/release-guard.mjs`, the publication guard extracted out of inline shell this cycle — it correctly resolved a dispatch off `main` to a dry run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)