### PR TITLE
feat: bun and pnpm channels, a checksums file, and a README that tells the truth

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -309,6 +309,53 @@ jobs:
       - name: Install through the real installer wrapper
         run: node scripts/smoke-installer.mjs
 
+  # The roadmap has claimed since it was written that `bun add -g` and
+  # `pnpm add -g` work natively, and until now nothing had ever run either. They
+  # do work — but both installations reported themselves as `npm` and were handed
+  # `npm install -g looptroop@latest`, which does not upgrade either of them. It
+  # installs a second copy under npm's prefix and leaves the first where it was,
+  # after which PATH order decides which one answers.
+  #
+  # That is the Homebrew-upgrade bug in a different manager, and it was found by
+  # running the thing rather than by reading it. Windows is in the matrix because
+  # the shim is the part that differs — `.cmd` wrappers there, symlinks and
+  # scripts elsewhere — and the shim is what a user actually invokes.
+  #
+  # Both managers are installed from npm at pinned versions rather than through
+  # a setup action, so there is one place versions live and no new third-party
+  # action in the supply chain.
+  node-managers:
+    name: Global install (${{ matrix.manager }} on ${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 25
+    strategy:
+      fail-fast: false
+      matrix:
+        manager: [bun, pnpm]
+        os: [ubuntu-latest, windows-latest]
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+        with:
+          node-version: 24.15.0
+          cache: npm
+
+      - name: Pin npm to the declared version
+        run: node scripts/pin-npm.mjs
+        shell: bash
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build application
+        run: npm run build
+
+      - name: Install ${{ matrix.manager }}
+        run: npm install -g ${{ matrix.manager == 'bun' && 'bun@1.3.14' || 'pnpm@11.21.0' }}
+
+      - name: Install globally with ${{ matrix.manager }} and check what it reports
+        run: node scripts/smoke-node-manager.mjs ${{ matrix.manager }}
+
   # The bundle the managed package channels will install. It is resolved and
   # archived once, on Linux, and then unpacked by Homebrew on macOS and by Scoop
   # and Chocolatey on Windows — so it is built here exactly once too, and the
@@ -821,7 +868,7 @@ jobs:
   # unconditional, so skipped means a dependency of theirs failed.
   packaging:
     name: Packaging
-    needs: [smoke-installer, bundle, bundle-runs, formula-audit, channel-install, choco-install, binary, winget-install, aur-package]
+    needs: [smoke-installer, node-managers, bundle, bundle-runs, formula-audit, channel-install, choco-install, binary, winget-install, aur-package]
     if: always()
     runs-on: ubuntu-latest
     timeout-minutes: 5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -471,6 +471,7 @@ jobs:
             install.sh
             install.ps1
             release-manifest.json
+            checksums.sha256
           if-no-files-found: error
           retention-days: 14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ Unreleased changes appear first and represent commits that have not yet been inc
 
 > Changes merged since the last versioned release that have not yet shipped in a tagged version.
 
+### Added
+- Installing with **bun** and **pnpm** is now supported properly. Both could always install LoopTroop — it is the same package from the same registry — but neither was ever tried, and both installations reported themselves as npm ones and were told to upgrade with `npm install -g looptroop@latest`. That command does not upgrade a bun or pnpm installation: it installs a second copy under npm's prefix, leaves the original where it is, and which of the two runs afterwards depends on the order of your PATH. Each now has its own upgrade command, and CI installs LoopTroop globally with both, on Linux and Windows, and requires it to name the manager it was actually installed by. One thing pnpm users should know: pnpm will not resolve `@latest` to a version published in the last day or so, as a supply-chain protection, so it arrives on pnpm about a day after everywhere else.
+- Every release now publishes `checksums.sha256` alongside the assets, so a download can be checked with `sha256sum -c` — or `shasum -a 256 -c` on macOS, or `Get-FileHash` on Windows — rather than by reading hashes out of `release-manifest.json` by hand. It is generated from that manifest rather than by hashing the files a second time, so the two cannot disagree, and it is verified on Linux, macOS and Windows before a release publishes: both that the file is intact, and that what it claims about every other asset matches what the release recorded.
+
+### Fixed
+- The README no longer says the container image is published "from the next release onward"; it has been published for several releases. The install table now also marks which channels actually work today, rather than describing Chocolatey and WinGet as merely slower — a command that cannot succeed yet is not a slow command.
+
 ## 0.5.3 (2026-08-14)
 
 

--- a/README.md
+++ b/README.md
@@ -189,42 +189,47 @@ review gates.
 
 ### Or use a package manager
 
-> **Chocolatey lags the other channels.** Every version goes through community
-> moderation before the feed serves it, and no release waits on that — so a new
-> version reaches Homebrew, Scoop and npm first, and Chocolatey once it clears.
+| | Install | Upgrade | |
+|---|---|---|---|
+| **npm** (everywhere) | `npm install -g looptroop` | `npm install -g looptroop@latest` | ✅ |
+| **bun** (everywhere) | `bun add -g looptroop` | `bun add -g looptroop@latest` | ✅ |
+| **pnpm** (everywhere) | `pnpm add -g looptroop` | `pnpm add -g looptroop@latest` | ✅ |
+| **Homebrew** (macOS, Linux) | `brew install looptroop-ai/tap/looptroop` | `brew upgrade looptroop` | ✅ |
+| **Scoop** (Windows) | `scoop bucket add looptroop https://github.com/looptroop-ai/scoop-bucket`<br>`scoop install looptroop` | `scoop update looptroop` | ✅ |
+| **Docker** | `docker pull looptroopai/looptroop:latest` | `docker pull looptroopai/looptroop:latest` | ✅ |
+| **Chocolatey** (Windows) | `choco install looptroop` | `choco upgrade looptroop` | ⏳ |
+| **WinGet** (Windows) | `winget install LoopTroopAI.LoopTroop` | `looptroop stop`<br>`winget upgrade LoopTroopAI.LoopTroop` | ⏳ |
+| **AUR** (Arch Linux) | `yay -S looptroop-bin` | `yay -Syu looptroop-bin` | ⏳ |
 
-| | Install | Upgrade |
-|---|---|---|
-| **Homebrew** (macOS, Linux) | `brew install looptroop-ai/tap/looptroop` | `brew upgrade looptroop` |
-| **Scoop** (Windows) | `scoop bucket add looptroop https://github.com/looptroop-ai/scoop-bucket`<br>`scoop install looptroop` | `scoop update looptroop` |
-| **Chocolatey** (Windows) | `choco install looptroop` | `choco upgrade looptroop` |
-| **WinGet** (Windows) | `winget install LoopTroopAI.LoopTroop` | `looptroop stop`<br>`winget upgrade LoopTroopAI.LoopTroop` |
-| **AUR** (Arch Linux) | `yay -S looptroop-bin` | `yay -Syu looptroop-bin` |
-| **npm** (everywhere) | `npm install -g looptroop` | `npm install -g looptroop@latest` |
-| **Docker** | `docker pull looptroopai/looptroop:latest` | `docker pull looptroopai/looptroop:latest` |
+⏳ **means the command does not work yet.** Those three packages are built and
+tested on every change, and each is waiting on somebody else: Chocolatey on
+community moderation, WinGet on a pull request being reviewed at Microsoft, and
+the AUR on registration reopening after a security incident. The commands are
+listed because they are what will work, unchanged, the day each clears. Until
+then, every ✅ row is a real alternative on the same platform.
 
-WinGet arrives later than the others for the same reason Chocolatey does: every
-submission is a pull request reviewed by people at Microsoft. `looptroop stop`
-before upgrading is not optional there — Windows will not replace a running
-executable, and the daemon holds it open.
-
-> **The AUR package is not published yet.** New registrations at the AUR are
-> closed following a security incident, so there is no account to publish
-> `looptroop-bin` from. The package is written and tested — CI builds it with
-> `makepkg`, lints it with `namcap`, installs it with `pacman` and removes it
-> again on every change — and the release workflow will publish it once an
-> account exists. Until then, Arch users can install with npm, or build the
-> package from this repository. `yay` is one AUR helper of several; `paru` and
-> the rest work the same way.
+The current state of all three, and everything below in more detail, is on the
+[Installation](https://www.looptroop.ovh/docs/installation) page.
 
 `looptroop doctor` tells you which of these your copy came from and the exact
-command that upgrades it.
+command that upgrades it — and each manager is given *its own* upgrade command,
+because `npm install -g` run against a bun or pnpm installation does not upgrade
+it. It installs a second copy under npm's prefix and leaves the first one alone.
 
-The three package managers install a bundle built once per release, with every
-dependency resolved at build time — so everyone on those channels runs the exact
-versions the release was tested against. Installing through npm resolves the
-version ranges afresh on your machine, which is how npm is supposed to work and
-is worth knowing when comparing two installations.
+Two differences worth knowing before comparing two installations:
+
+- **Homebrew, Scoop and Chocolatey install a locked bundle** built once per
+  release with every dependency resolved at build time, so everyone on those
+  channels runs the exact versions the release was tested against. npm, bun and
+  pnpm resolve the version ranges afresh on your machine, which is how they are
+  supposed to work.
+- **pnpm holds a new version back for about a day.** It will not resolve a tag
+  to a version published in the last 24 hours — a supply-chain protection, on by
+  default — so `pnpm add -g looptroop@latest` installs the newest release older
+  than that window. Asking for an exact version bypasses it.
+
+`looptroop stop` before a WinGet upgrade is not optional: Windows will not
+replace a running executable, and the daemon holds it open.
 
 ### Or download a binary
 
@@ -235,9 +240,20 @@ carries its own Node runtime, so it needs nothing installed but git — which is
 what WinGet installs, and why that channel declares no Node dependency.
 
 Each archive is listed in the release's `release-manifest.json` with its
-checksum, and carries a build provenance attestation. Intel Macs are not among
-them: Node cannot build a single-file executable for that target, so use
-Homebrew or npm there.
+checksum, and carries a build provenance attestation. Every release also
+publishes `checksums.sha256`, so you can check a download with the tool you
+already have:
+
+```bash
+sha256sum -c checksums.sha256        # shasum -a 256 -c on macOS
+```
+
+```powershell
+Get-FileHash looptroop-<version>-win-x64.zip -Algorithm SHA256
+```
+
+Intel Macs are not among the binaries: Node cannot build a single-file
+executable for that target, so use Homebrew or npm there.
 
 The installer will place one for you, into `~/.looptroop` unless you say
 otherwise:
@@ -296,11 +312,6 @@ needs — Node, git and `gh` are in the image:
 ```bash
 docker pull looptroopai/looptroop:latest
 ```
-
-> **From the next release onward.** The image is built and tested on every
-> change, but it is published by the release workflow, so no tag exists in a
-> registry until the first release runs. Until then, build it yourself with
-> `docker build -t looptroopai/looptroop .` from a checkout.
 
 Two things it still needs from you, both deliberately not baked in.
 
@@ -493,6 +504,8 @@ Useful pages:
 
 | Page | What it explains |
 | --- | --- |
+| [Installation](https://www.looptroop.ovh/docs/installation) | Every channel, what each installs, upgrading, uninstalling, and verifying a download |
+| [CLI Reference](https://www.looptroop.ovh/docs/cli) | Every command and option, the `--json` output, and what running as a service means |
 | [Getting Started](https://www.looptroop.ovh/docs/getting-started) | Setup, startup, ports, and first project attach |
 | [Configuration](https://www.looptroop.ovh/docs/configuration) | All profile settings with defaults, ranges, and trade-offs |
 | [Ticket Lifecycle Screenshots](https://www.looptroop.ovh/docs/ticket-lifecycle-screenshots) | Visual walkthrough of every workflow status with screenshots and action summaries |

--- a/scripts/release-manifest.ts
+++ b/scripts/release-manifest.ts
@@ -114,6 +114,33 @@ for (const path of extraAssets) {
   assets[name] = digest(path)
 }
 
+/**
+ * `checksums.sha256`, in the format `sha256sum -c` reads.
+ *
+ * Rendered from the assets above rather than by hashing the files a second
+ * time. A release already has one authority on what it is made of, and a second
+ * independent computation is a second thing that can disagree with it.
+ *
+ * It is written before it is recorded, and it lists neither itself nor the
+ * manifest — so there is no file whose own hash has to appear inside it. That
+ * is what lets it be an ordinary asset: recorded in `assets` like everything
+ * else, and therefore uploaded, resumed, verified and protected against a
+ * same-version rewrite by machinery that already exists, with no special case
+ * anywhere.
+ *
+ * Two spaces between hash and name is not cosmetic: `sha256sum` reads one space
+ * as text mode and two as binary, and a single space fails on Windows archives.
+ */
+const CHECKSUMS_ASSET = 'checksums.sha256'
+const checksumsPath = resolve(dirname(outPath), CHECKSUMS_ASSET)
+if (CHECKSUMS_ASSET in assets) fail(`An asset is already named ${CHECKSUMS_ASSET}.`)
+
+const checksumLines = Object.entries(assets)
+  .map(([name, entry]) => `${entry.sha256}  ${name}`)
+  .sort()
+writeFileSync(checksumsPath, `${checksumLines.join('\n')}\n`)
+assets[CHECKSUMS_ASSET] = digest(checksumsPath)
+
 const manifest = {
   name: manifestJson.name,
   version: manifestJson.version,

--- a/scripts/release-verify-artifact.ts
+++ b/scripts/release-verify-artifact.ts
@@ -115,6 +115,46 @@ if (assetsDir !== null) {
     }
     otherAssets.push(`  ${name.padEnd(34)} ${assetSha}`)
   }
+
+  // `checksums.sha256` matching its own manifest entry only proves the file was
+  // not corrupted in transit. It does not prove it says the right thing — a
+  // correctly-hashed wrong file passes that check and fails the first person who
+  // runs `sha256sum -c` against it. So read it and compare what it claims about
+  // every other asset with what the manifest records.
+  const checksumsName = 'checksums.sha256'
+  if (Object.hasOwn(digestedAssets(manifest), checksumsName)) {
+    let listed: Map<string, string>
+    try {
+      listed = new Map(
+        readFileSync(join(resolve(assetsDir), checksumsName), 'utf8')
+          .split('\n')
+          .filter((line) => line.trim() !== '')
+          .map((line) => {
+            const [sha, ...rest] = line.trim().split(/\s+/)
+            return [rest.join(' '), sha ?? ''] as const
+          }),
+      )
+    } catch {
+      listed = new Map()
+      failures.push(`${checksumsName} could not be read`)
+    }
+
+    for (const [name, expected] of Object.entries(digestedAssets(manifest))) {
+      // It cannot list itself, and the manifest is the thing being checked
+      // against rather than a payload file, so neither belongs in it.
+      if (name === checksumsName) continue
+      const claimed = listed.get(name)
+      if (claimed === undefined) failures.push(`${checksumsName} does not list ${name}`)
+      else if (claimed !== expected.sha256) {
+        failures.push(`${checksumsName} claims ${name} is ${claimed}, the manifest records ${expected.sha256}`)
+      }
+    }
+    for (const name of listed.keys()) {
+      if (!Object.hasOwn(digestedAssets(manifest), name)) {
+        failures.push(`${checksumsName} lists ${name}, which this release does not publish`)
+      }
+    }
+  }
 }
 
 if (failures.length > 0) {

--- a/scripts/smoke-node-manager.mjs
+++ b/scripts/smoke-node-manager.mjs
@@ -1,0 +1,171 @@
+#!/usr/bin/env node
+/**
+ * Installs the packed tarball globally with bun or pnpm, and proves the result
+ * knows what it is.
+ *
+ *   node scripts/smoke-node-manager.mjs bun
+ *   node scripts/smoke-node-manager.mjs pnpm
+ *
+ * The roadmap has claimed since the beginning that `bun add -g` and
+ * `pnpm add -g` work natively, and nothing had ever run either. They do — but
+ * both installations reported themselves as `npm` and were told to upgrade with
+ * `npm install -g`, which does not upgrade either of them: it installs a second
+ * copy under npm's prefix and leaves the first one where it was, after which
+ * PATH order decides which one answers. That is the Homebrew-upgrade bug in a
+ * different manager, and it is what this smoke exists to keep fixed.
+ *
+ * So the assertion is not "a channel line was printed". It is that `doctor`
+ * names *this* manager and offers *its* upgrade command — the weaker assertion
+ * passes on exactly the bug being ruled out.
+ *
+ * The tarball is installed from a local path rather than from the registry.
+ * That tests the artifact this commit produces rather than the last published
+ * one, and it sidesteps pnpm's release-age window (see below), which would
+ * otherwise make the result depend on what day it is.
+ */
+import { spawnSync } from 'node:child_process'
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join, resolve } from 'node:path'
+
+const IS_WINDOWS = process.platform === 'win32'
+const MANAGER = process.argv[2]
+
+if (MANAGER !== 'bun' && MANAGER !== 'pnpm') {
+  process.stderr.write('Usage: node scripts/smoke-node-manager.mjs <bun|pnpm>\n')
+  process.exit(1)
+}
+
+const failures = []
+let step = 0
+
+function heading(text) {
+  step += 1
+  process.stdout.write(`\n${step}. ${text}\n`)
+}
+
+function check(ok, message) {
+  process.stdout.write(`  ${ok ? 'ok' : 'FAIL'}  ${message}\n`)
+  if (!ok) failures.push(message)
+  return ok
+}
+
+function run(command, args, options = {}) {
+  const result = spawnSync(command, args, {
+    encoding: 'utf8',
+    shell: IS_WINDOWS,
+    ...options,
+    env: { ...process.env, ...options.env },
+  })
+  return {
+    status: result.status,
+    stdout: result.stdout ?? '',
+    stderr: result.stderr ?? '',
+    output: `${result.stdout ?? ''}${result.stderr ?? ''}`,
+  }
+}
+
+const repoRoot = resolve(import.meta.dirname, '..')
+const version = JSON.parse(readFileSync(join(repoRoot, 'package.json'), 'utf8')).version
+const home = mkdtempSync(join(tmpdir(), `looptroop-${MANAGER}-`))
+/** Nothing here to resolve against, so a path taken from the cwd finds nothing. */
+const empty = mkdtempSync(join(tmpdir(), 'looptroop-empty-'))
+
+/**
+ * Where each manager puts a global install, and how to point it somewhere
+ * disposable. Neither may write to the runner's real home: a smoke that leaves
+ * a global install behind changes the machine every later job runs on.
+ *
+ * pnpm refuses to install globally at all when its global bin directory is not
+ * on PATH — `pnpm setup` is the documented fix, and setting the variable and
+ * the PATH is what that does.
+ */
+const binDir = MANAGER === 'bun' ? join(home, 'bin') : join(home, 'bin')
+const managerEnv = MANAGER === 'bun'
+  ? { BUN_INSTALL: home }
+  : { PNPM_HOME: home }
+
+mkdirSync(binDir, { recursive: true })
+
+const childEnv = {
+  ...managerEnv,
+  PATH: `${binDir}${IS_WINDOWS ? ';' : ':'}${process.env.PATH}`,
+  LOOPTROOP_OPENCODE_MODE: 'mock',
+  LOOPTROOP_CONFIG_DIR: join(home, 'config'),
+}
+
+const shim = join(binDir, IS_WINDOWS ? 'looptroop.cmd' : 'looptroop')
+
+try {
+  heading(`pack the tarball this commit produces`)
+  const pack = run('npm', ['pack', '--silent'], { cwd: repoRoot })
+  const tarball = pack.stdout.trim().split(/\r?\n/).filter(Boolean).pop()
+  if (!check(pack.status === 0 && Boolean(tarball), 'npm pack produced a tarball')) {
+    process.stderr.write(pack.output)
+    throw new Error('pack failed')
+  }
+  const tarballPath = join(repoRoot, tarball)
+  process.stdout.write(`      ${tarball}\n`)
+
+  heading(`install it globally with ${MANAGER}`)
+  const install = run(MANAGER, ['add', '-g', tarballPath], { cwd: empty, env: childEnv })
+  if (!check(install.status === 0, `${MANAGER} add -g succeeded`)) {
+    process.stderr.write(install.output)
+  }
+
+  heading('the shim it created runs, from a directory holding nothing')
+  // Through the shim on PATH, never `node <path>`: the shim is the part that
+  // differs between managers and between platforms, so invoking the file
+  // directly would skip the only thing this step is here to prove.
+  const reported = run('looptroop', ['--version'], { cwd: empty, env: childEnv })
+  check(reported.status === 0, 'looptroop --version exited 0')
+  check(
+    reported.stdout.trim() === version,
+    `looptroop --version reported ${version} (got ${JSON.stringify(reported.stdout.trim())})`,
+  )
+
+  heading(`doctor names ${MANAGER}, and its own upgrade command`)
+  // `doctor` exits non-zero whenever any check fails, and a CI runner has no
+  // OpenCode — so the exit code is not the assertion, the install line is.
+  const doctor = run('looptroop', ['doctor', '--json'], { cwd: empty, env: childEnv })
+  let install_ = null
+  try {
+    install_ = JSON.parse(doctor.stdout).checks.find((c) => c.name === 'install')
+  } catch {
+    check(false, `doctor --json emitted parseable JSON (got ${JSON.stringify(doctor.stdout.slice(0, 200))})`)
+  }
+  if (install_ !== null && install_ !== undefined) {
+    // The whole point. Before bun and pnpm had channels of their own, both of
+    // these said `npm` and offered `npm install -g looptroop@latest`.
+    check(
+      install_.detail.startsWith(`${MANAGER} `),
+      `doctor reports the ${MANAGER} channel (got ${JSON.stringify(install_.detail)})`,
+    )
+    check(
+      install_.detail.includes(`${MANAGER} add -g looptroop@latest`),
+      `doctor offers ${MANAGER}'s upgrade command, not npm's`,
+    )
+  }
+
+  heading(`uninstalling with ${MANAGER} removes the shim`)
+  const remove = run(MANAGER, ['remove', '-g', 'looptroop'], { cwd: empty, env: childEnv })
+  check(remove.status === 0, `${MANAGER} remove -g succeeded`)
+  check(!existsSync(shim), 'the shim is gone')
+
+  rmSync(tarballPath, { force: true })
+} finally {
+  for (const dir of [home, empty]) {
+    try {
+      rmSync(dir, { recursive: true, force: true, maxRetries: 10, retryDelay: 100 })
+    } catch {
+      // A leftover temp directory is not worth failing a passing smoke over.
+    }
+  }
+}
+
+process.stdout.write(
+  failures.length === 0
+    ? `\nPASS: ${MANAGER} installs LoopTroop globally, and it knows it.\n`
+    : `\nFAIL: ${failures.length} check(s) failed.\n${failures.map((f) => `  - ${f}`).join('\n')}\n`,
+)
+process.exit(failures.length === 0 ? 0 : 1)

--- a/server/cli/cli.ts
+++ b/server/cli/cli.ts
@@ -2,7 +2,13 @@ import { parseArgs } from 'node:util'
 import { APP_VERSION } from '../lib/appVersion'
 import { DAEMON_ARGV } from './daemonHandoff'
 
-const USAGE = `LoopTroop — local AI coding orchestration
+/**
+ * Exported so the published CLI reference can be generated from it rather than
+ * transcribed. The documentation lives in another repository, which fetches this
+ * file at a release tag and rewrites its command block from this string — so the
+ * page cannot quietly fall behind a flag added here.
+ */
+export const USAGE = `LoopTroop — local AI coding orchestration
 
 Usage: looptroop <command> [options]
 

--- a/server/lib/installChannel.ts
+++ b/server/lib/installChannel.ts
@@ -4,7 +4,7 @@ import { fileURLToPath } from 'node:url'
 import { readSettingsFile, writeSettingsFile } from './appSettings'
 import { isSea } from './isSea'
 
-export type InstallChannel = 'npm' | 'homebrew' | 'scoop' | 'chocolatey' | 'winget' | 'aur' | 'binary' | 'container' | 'source' | 'unknown'
+export type InstallChannel = 'npm' | 'bun' | 'pnpm' | 'homebrew' | 'scoop' | 'chocolatey' | 'winget' | 'aur' | 'binary' | 'container' | 'source' | 'unknown'
 
 export interface InstallInfo {
   channel: InstallChannel
@@ -35,6 +35,13 @@ const UPGRADE_PREREQUISITES: Partial<Record<InstallChannel, string>> = {
 
 const UPGRADE_COMMANDS: Record<InstallChannel, string> = {
   npm: 'npm install -g looptroop@latest',
+  // Their own commands, not npm's. All three install the same package from the
+  // same registry, but each keeps its global tree somewhere the others do not
+  // look — so `npm install -g` run against a bun or pnpm installation does not
+  // upgrade it. It installs a *second* copy under npm's prefix and leaves the
+  // first where it was, and which one answers then depends on PATH order.
+  bun: 'bun add -g looptroop@latest',
+  pnpm: 'pnpm add -g looptroop@latest',
   homebrew: 'brew upgrade looptroop',
   scoop: 'scoop update looptroop',
   chocolatey: 'choco upgrade looptroop',
@@ -162,6 +169,25 @@ function detectFromShape(moduleDir: string): InstallChannel {
   // `winget-pkgs`, for one, which is exactly what somebody working on this
   // package would have — must not be read as an install.
   if (/\/WinGet\/(Links|Packages)(\/|$)/i.test(normalized)) return 'winget'
+
+  // bun and pnpm before npm, because a global install by either of them also
+  // lands in a directory called `node_modules/looptroop` and the npm rule below
+  // would claim it. Getting that wrong is not cosmetic: it answers with
+  // `npm install -g`, which does not upgrade a bun or pnpm installation — it
+  // creates a second one under npm's prefix. That is the Homebrew-upgrade bug
+  // again, and it was measured, not predicted: both managers reported `npm`.
+  //
+  // pnpm links a global install out of its content-addressable store, so the
+  // *resolved* path of the running module is inside `store/v<n>/links/…` and
+  // never the `global/v<n>/…` directory its shim names. Node resolves symlinks
+  // when it loads a module, so the store path is what detection actually sees.
+  if (/\/store\/v\d+\/links\/.*\/node_modules\/looptroop\//i.test(normalized)) return 'pnpm'
+  // The virtual store, for a layout that keeps the package inside `.pnpm`.
+  if (/\/\.pnpm\/looptroop@/i.test(normalized)) return 'pnpm'
+  // bun's global tree is always `<BUN_INSTALL>/install/global`, whatever
+  // `BUN_INSTALL` points at — the doubled `install/global` is bun's, not npm's.
+  if (/\/install\/global\/node_modules\/looptroop\//i.test(normalized)) return 'bun'
+
   if (/\/node_modules\/looptroop\//.test(normalized)) return 'npm'
 
   // A checkout has the sources a published package never ships.

--- a/tests/releaseAssets.test.ts
+++ b/tests/releaseAssets.test.ts
@@ -164,3 +164,50 @@ describe('comparing a drafted manifest against this build', () => {
     expect(differences.length).toBeGreaterThan(0)
   })
 })
+
+/**
+ * `checksums.sha256` is what a person runs `sha256sum -c` against, and the
+ * roadmap asked for it from the start. The only decision it needed was whether
+ * it belongs in the manifest, and two review rounds argued that it could not —
+ * that a file hashing the manifest cannot have its own hash recorded in it.
+ *
+ * It never hashes the manifest. It lists the payload, so recording it closes no
+ * loop, and being an ordinary asset is what makes it inherit the upload, the
+ * resume plan, the cross-platform verification and the same-version rewrite
+ * protection with no special case anywhere.
+ */
+describe('the checksums file', () => {
+  const CHECKSUMS = 'checksums.sha256'
+
+  function withChecksums(): ReleaseManifest {
+    const base = manifest()
+    return {
+      ...base,
+      assets: { ...base.assets, [CHECKSUMS]: { bytes: 500, sha256: 'ee' } },
+    }
+  }
+
+  it('is uploaded like every other asset', () => {
+    expect(requiredAssets(withChecksums())).toContain(CHECKSUMS)
+  })
+
+  /**
+   * The failure the workflow's explicit upload globs would have caused: the
+   * manifest travels between jobs, the file does not, and every consumer that
+   * reads the manifest then looks for something that is not there.
+   */
+  it('is restored by a resumed draft that is missing it', () => {
+    const plan = planDraftAssets(withChecksums(), [MANIFEST_ASSET])
+    expect(plan.action).toBe('upload')
+    if (plan.action === 'upload') expect(plan.missing).toContain(CHECKSUMS)
+  })
+
+  it('is compared byte for byte when a release is republished', () => {
+    const differences = manifestDifferences(
+      withChecksums(),
+      { ...withChecksums(), assets: { ...withChecksums().assets, [CHECKSUMS]: { bytes: 500, sha256: 'ff' } } },
+    )
+
+    expect(differences.join(' ')).toContain(CHECKSUMS)
+  })
+})

--- a/tests/updateCheck.test.ts
+++ b/tests/updateCheck.test.ts
@@ -56,8 +56,36 @@ describe('install channel detection', () => {
     // command that would not upgrade anything.
     ['/c/Program Files/WinGet/Links', 'winget'],
     ['/c/Program Files/WinGet/Packages/LoopTroopAI.LoopTroop_Microsoft.Winget.Source_8wekyb3d8bbwe/looptroop/dist/server/cli', 'winget'],
+    // Both of these paths were taken from real global installs, not invented:
+    // `bun add -g looptroop` and `pnpm add -g looptroop` were run and the
+    // resolved module directory read back. Both used to answer `npm`, and so
+    // told the user to run `npm install -g`, which does not upgrade either of
+    // them — it installs a second copy under npm's prefix.
+    //
+    // bun keeps its global tree at `<BUN_INSTALL>/install/global`.
+    ['/home/u/.bun/install/global/node_modules/looptroop/dist/server/cli', 'bun'],
+    // pnpm links the package out of its content-addressable store, and Node
+    // resolves the symlink when it loads the module — so what detection sees is
+    // the store path, not the `global/v11/…` directory pnpm's shim names.
+    ['/home/u/.local/share/pnpm/store/v11/links/@/looptroop/9.9.9/abc123/node_modules/looptroop/dist/server/cli', 'pnpm'],
+    ['/home/u/.local/share/pnpm/global/v11/node_modules/.pnpm/looptroop@9.9.9/node_modules/looptroop/dist/server/cli', 'pnpm'],
   ])('detects %s as %s', (moduleDir, expected) => {
     expect(detectInstallChannel(moduleDir)).toBe(expected)
+  })
+
+  /**
+   * The upgrade command is the whole reason detection exists, so assert the
+   * commands themselves rather than only the channel names. Each manager keeps
+   * its global tree somewhere the other two do not look.
+   */
+  it.each([
+    ['/usr/local/lib/node_modules/looptroop/dist/server/cli', 'npm', 'npm install -g looptroop@latest'],
+    ['/home/u/.bun/install/global/node_modules/looptroop/dist/server/cli', 'bun', 'bun add -g looptroop@latest'],
+    ['/home/u/.local/share/pnpm/store/v11/links/@/looptroop/9.9.9/abc123/node_modules/looptroop/dist/server/cli', 'pnpm', 'pnpm add -g looptroop@latest'],
+  ])('upgrades a %s install as %s with its own command', (moduleDir, channel, expected) => {
+    const info = getInstallInfo(moduleDir)
+    expect(info.channel).toBe(channel)
+    expect(info.upgradeCommand).toBe(expected)
   })
 
   /**


### PR DESCRIPTION
Phase 7, application half. The documentation half lives in `LoopTroop-Website` and is prepared alongside this.

## bun and pnpm are real channels now

The roadmap has claimed since it was written that `bun add -g` and `pnpm add -g` work natively. Nothing had ever run either. Both were run.

They work — and both installations then reported themselves as npm ones, and were told to upgrade with `npm install -g looptroop@latest`. That command does not upgrade a bun or pnpm installation. It installs a **second** copy under npm's prefix, leaves the first where it was, and PATH order decides which one answers afterwards. It is the Homebrew-upgrade bug in a different manager.

Both now have a channel, detection ahead of the npm rule, and their own upgrade command. The patterns come from real installs, not from documentation: bun keeps its global tree at `<BUN_INSTALL>/install/global`, and pnpm links the package out of its content-addressable store, so the resolved module path is inside `store/v<n>/links/…` and never the `global/v<n>/…` directory its shim names.

`scripts/smoke-node-manager.mjs` installs the packed tarball globally with each manager, runs it through the shim from an empty directory, and requires `doctor` to name **that** manager and offer **its** upgrade command — asserting merely that an install line was printed would pass on exactly the bug being ruled out. Windows is in the matrix because the shim is the part that differs. The job joins `packaging.needs`, which is the required check.

One finding for the docs: pnpm will not resolve a tag to a version published in the last ~24 hours, as a supply-chain protection. So LoopTroop arrives on pnpm about a day after everywhere else. Not a bug in either project, but users will notice.

## `checksums.sha256`

Asked for by the roadmap, never produced. It is an ordinary asset recorded in the manifest, generated from the assets map rather than by hashing everything a second time.

Two failures this caught:

- The workflow uploads `release-artefacts` from an **explicit glob list**, which `checksums.sha256` matched none of. The manifest would have travelled between jobs and the file would not, failing every consumer that reads the manifest.
- A checksums file can match its own manifest entry and still say the wrong thing about every other asset — a correctly-hashed wrong file passes a byte check and fails the first person who runs `sha256sum -c`. Verification now compares its claims against the manifest in both directions.

## README

The container note said the image would be published "from the next release onward"; it has been published for several releases. The install table listed three commands that cannot succeed today as though they were merely slower, and now carries a status column.

## Checks

Full suite green locally: 287 files, 3309 passed, 3 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)