### PR TITLE
release: v0.5.4

### DIFF
--- a/.github/releases/0.5.4.md
+++ b/.github/releases/0.5.4.md
@@ -1,0 +1,14 @@
+## 0.5.4 (2026-08-14)
+
+
+### Summary
+- Installing with **bun** and **pnpm** is properly supported. Both could always install LoopTroop, but neither had ever been tried, and both installations reported themselves as npm ones — so they were told to upgrade with a command that does not upgrade them, and quietly installs a second copy alongside instead. Each now has its own upgrade command, proved by installing globally with both on Linux and Windows.
+- Every release now publishes `checksums.sha256`, so a download can be checked with `sha256sum -c` rather than by reading hashes out of a JSON file by hand.
+- The documentation now describes LoopTroop as something you install. Every published page still opened with `git clone` and `npm run dev`, four releases after it began installing from seven channels and running as a background service. There are new **Installation** and **CLI Reference** pages, and the rest of the site has been brought in line.
+
+### Added
+- Installing with **bun** and **pnpm** is now supported properly. Both could always install LoopTroop — it is the same package from the same registry — but neither was ever tried, and both installations reported themselves as npm ones and were told to upgrade with `npm install -g looptroop@latest`. That command does not upgrade a bun or pnpm installation: it installs a second copy under npm's prefix, leaves the original where it is, and which of the two runs afterwards depends on the order of your PATH. Each now has its own upgrade command, and CI installs LoopTroop globally with both, on Linux and Windows, and requires it to name the manager it was actually installed by. One thing pnpm users should know: pnpm will not resolve `@latest` to a version published in the last day or so, as a supply-chain protection, so it arrives on pnpm about a day after everywhere else.
+- Every release now publishes `checksums.sha256` alongside the assets, so a download can be checked with `sha256sum -c` — or `shasum -a 256 -c` on macOS, or `Get-FileHash` on Windows — rather than by reading hashes out of `release-manifest.json` by hand. It is generated from that manifest rather than by hashing the files a second time, so the two cannot disagree, and it is verified on Linux, macOS and Windows before a release publishes: both that the file is intact, and that what it claims about every other asset matches what the release recorded.
+
+### Fixed
+- The README no longer says the container image is published "from the next release onward"; it has been published for several releases. The install table now also marks which channels actually work today, rather than describing Chocolatey and WinGet as merely slower — a command that cannot succeed yet is not a slow command.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ Unreleased changes appear first and represent commits that have not yet been inc
 
 > Changes merged since the last versioned release that have not yet shipped in a tagged version.
 
+## 0.5.4 (2026-08-14)
+
+
+### Summary
+- Installing with **bun** and **pnpm** is properly supported. Both could always install LoopTroop, but neither had ever been tried, and both installations reported themselves as npm ones — so they were told to upgrade with a command that does not upgrade them, and quietly installs a second copy alongside instead. Each now has its own upgrade command, proved by installing globally with both on Linux and Windows.
+- Every release now publishes `checksums.sha256`, so a download can be checked with `sha256sum -c` rather than by reading hashes out of a JSON file by hand.
+- The documentation now describes LoopTroop as something you install. Every published page still opened with `git clone` and `npm run dev`, four releases after it began installing from seven channels and running as a background service. There are new **Installation** and **CLI Reference** pages, and the rest of the site has been brought in line.
+
 ### Added
 - Installing with **bun** and **pnpm** is now supported properly. Both could always install LoopTroop — it is the same package from the same registry — but neither was ever tried, and both installations reported themselves as npm ones and were told to upgrade with `npm install -g looptroop@latest`. That command does not upgrade a bun or pnpm installation: it installs a second copy under npm's prefix, leaves the original where it is, and which of the two runs afterwards depends on the order of your PATH. Each now has its own upgrade command, and CI installs LoopTroop globally with both, on Linux and Windows, and requires it to name the manager it was actually installed by. One thing pnpm users should know: pnpm will not resolve `@latest` to a version published in the last day or so, as a supply-chain protection, so it arrives on pnpm about a day after everywhere else.
 - Every release now publishes `checksums.sha256` alongside the assets, so a download can be checked with `sha256sum -c` — or `shasum -a 256 -c` on macOS, or `Get-FileHash` on Windows — rather than by reading hashes out of `release-manifest.json` by hand. It is generated from that manifest rather than by hashing the files a second time, so the two cannot disagree, and it is verified on Linux, macOS and Windows before a release publishes: both that the file is intact, and that what it claims about every other asset matches what the release recorded.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "looptroop",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "looptroop",
-      "version": "0.5.3",
+      "version": "0.5.4",
       "license": "MIT",
       "dependencies": {
         "@hono/node-server": "^2.0.12",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "looptroop",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "description": "Local AI coding orchestration for repo-scale work: LLM-council planning, Ralph-loop recovery, isolated OpenCode worktrees, and human-gated PR delivery.",
   "type": "module",
   "keywords": [


### PR DESCRIPTION
Cuts 0.5.4. Merging this publishes to npm, GitHub Releases, Docker Hub, GHCR, Homebrew and Scoop. Chocolatey, WinGet and the AUR stay paused.

## Dry run

[31795283294](https://github.com/looptroop-ai/LoopTroop/actions/runs/31795283294) — **success**, publishing nothing. All four binaries built, the artefact verified on Linux, macOS and Windows, every publish job correctly skipped.

That verification is the one that matters this release: it is the job that fails if `checksums.sha256` does not travel between jobs, and it passed on all three platforms. The build log confirms the manifest recorded the file (826 bytes, covering all ten assets) and that it was uploaded with the rest.

## What ships

- **bun and pnpm install channels**, with their own upgrade commands. Both managers could always install LoopTroop; both installations reported themselves as npm ones and were told to upgrade with a command that installs a second copy alongside rather than upgrading theirs.
- **`checksums.sha256`** on every release, generated from `release-manifest.json` so the two cannot disagree, and verified in both directions before anything publishes.
- **README corrections** — the container image is no longer described as unpublished, and the three channels that cannot be installed yet say so.

The documentation half is [LoopTroop-Website#2](https://github.com/looptroop-ai/LoopTroop-Website/pull/2), merged immediately after this release goes public.

🤖 Generated with [Claude Code](https://claude.com/claude-code)