### PR TITLE
fix: a checksum command nobody could run, and an emergency release path that produced nothing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -481,7 +481,17 @@ jobs:
   verify-artifact:
     name: Verify artefact (${{ matrix.os }})
     needs: [detect, build]
-    if: needs.detect.outputs.proceed == 'true'
+    # `always()` for the same reason `build` has it: a *deliberately* skipped
+    # binary matrix must not skip everything downstream of it. GitHub propagates
+    # a skip through the graph even when an intermediate job ran via `always()`,
+    # so without this the `skip_binaries` bypass silently skipped verification,
+    # the draft, and therefore the whole release — the one path that exists to
+    # ship a security fix produced no verified artefact at all. Proved by
+    # dispatching it, not by reading it.
+    if: >-
+      always()
+      && needs.detect.outputs.proceed == 'true'
+      && needs.build.result == 'success'
     runs-on: ${{ matrix.os }}
     timeout-minutes: 30
     strategy:
@@ -535,7 +545,11 @@ jobs:
   verify-readonly:
     name: Verify read-only install
     needs: [detect, build]
-    if: needs.detect.outputs.proceed == 'true'
+    # See `verify-artifact`: skipped binaries must not skip verification.
+    if: >-
+      always()
+      && needs.detect.outputs.proceed == 'true'
+      && needs.build.result == 'success'
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
@@ -587,7 +601,14 @@ jobs:
   draft-release:
     name: Draft the GitHub release
     needs: [detect, build, verify-artifact, verify-readonly]
-    if: needs.detect.outputs.proceed == 'true'
+    # Every predecessor named explicitly, because `always()` removes the default
+    # that would have stopped here on a failure.
+    if: >-
+      always()
+      && needs.detect.outputs.proceed == 'true'
+      && needs.build.result == 'success'
+      && needs.verify-artifact.result == 'success'
+      && needs.verify-readonly.result == 'success'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -732,7 +732,17 @@ jobs:
   npm:
     name: Publish to npm
     needs: [detect, build, draft-release]
-    if: needs.detect.outputs.proceed == 'true' && needs.detect.outputs.dry_run == 'false'
+    # `always()` with every predecessor named, because the skip from a
+    # deliberately absent binary matrix propagates down the whole graph —
+    # even past jobs that ran via `always()` themselves. Without this the
+    # `skip_binaries` bypass builds and drafts a release and then publishes
+    # nothing, which is worse than failing.
+    if: >-
+      always()
+      && needs.detect.outputs.proceed == 'true'
+      && needs.detect.outputs.dry_run == 'false'
+      && needs.build.result == 'success'
+      && needs.draft-release.result == 'success'
     runs-on: ubuntu-latest
     timeout-minutes: 20
     environment: release
@@ -902,7 +912,16 @@ jobs:
   smoke:
     name: Registry smoke (${{ matrix.os }})
     needs: [detect, npm]
-    if: needs.detect.outputs.proceed == 'true' && needs.detect.outputs.dry_run == 'false'
+    # `always()` with every predecessor named, because the skip from a
+    # deliberately absent binary matrix propagates down the whole graph —
+    # even past jobs that ran via `always()` themselves. Without this the
+    # `skip_binaries` bypass builds and drafts a release and then publishes
+    # nothing, which is worse than failing.
+    if: >-
+      always()
+      && needs.detect.outputs.proceed == 'true'
+      && needs.detect.outputs.dry_run == 'false'
+      && needs.npm.result == 'success'
     runs-on: ${{ matrix.os }}
     timeout-minutes: 20
     strategy:
@@ -978,7 +997,17 @@ jobs:
   finalize:
     name: Tag and publish
     needs: [detect, build, smoke]
-    if: needs.detect.outputs.proceed == 'true' && needs.detect.outputs.dry_run == 'false'
+    # `always()` with every predecessor named, because the skip from a
+    # deliberately absent binary matrix propagates down the whole graph —
+    # even past jobs that ran via `always()` themselves. Without this the
+    # `skip_binaries` bypass builds and drafts a release and then publishes
+    # nothing, which is worse than failing.
+    if: >-
+      always()
+      && needs.detect.outputs.proceed == 'true'
+      && needs.detect.outputs.dry_run == 'false'
+      && needs.build.result == 'success'
+      && needs.smoke.result == 'success'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     # Deliberately *not* `environment: release`. That environment gates the one
@@ -1065,7 +1094,17 @@ jobs:
   container-build:
     name: Build container image (${{ matrix.arch }})
     needs: [detect, build, draft-release]
-    if: needs.detect.outputs.proceed == 'true' && needs.detect.outputs.dry_run == 'false'
+    # `always()` with every predecessor named, because the skip from a
+    # deliberately absent binary matrix propagates down the whole graph —
+    # even past jobs that ran via `always()` themselves. Without this the
+    # `skip_binaries` bypass builds and drafts a release and then publishes
+    # nothing, which is worse than failing.
+    if: >-
+      always()
+      && needs.detect.outputs.proceed == 'true'
+      && needs.detect.outputs.dry_run == 'false'
+      && needs.build.result == 'success'
+      && needs.draft-release.result == 'success'
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 45
     environment: release
@@ -1268,7 +1307,16 @@ jobs:
   container-manifest:
     name: Tag the container image
     needs: [detect, container-build]
-    if: needs.detect.outputs.proceed == 'true' && needs.detect.outputs.dry_run == 'false'
+    # `always()` with every predecessor named, because the skip from a
+    # deliberately absent binary matrix propagates down the whole graph —
+    # even past jobs that ran via `always()` themselves. Without this the
+    # `skip_binaries` bypass builds and drafts a release and then publishes
+    # nothing, which is worse than failing.
+    if: >-
+      always()
+      && needs.detect.outputs.proceed == 'true'
+      && needs.detect.outputs.dry_run == 'false'
+      && needs.container-build.result == 'success'
     runs-on: ubuntu-latest
     timeout-minutes: 20
     environment: release
@@ -1375,7 +1423,16 @@ jobs:
   container-verify:
     name: Verify container image (${{ matrix.arch }})
     needs: [detect, container-manifest]
-    if: needs.detect.outputs.proceed == 'true' && needs.detect.outputs.dry_run == 'false'
+    # `always()` with every predecessor named, because the skip from a
+    # deliberately absent binary matrix propagates down the whole graph —
+    # even past jobs that ran via `always()` themselves. Without this the
+    # `skip_binaries` bypass builds and drafts a release and then publishes
+    # nothing, which is worse than failing.
+    if: >-
+      always()
+      && needs.detect.outputs.proceed == 'true'
+      && needs.detect.outputs.dry_run == 'false'
+      && needs.container-manifest.result == 'success'
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 30
     permissions:
@@ -1584,10 +1641,18 @@ jobs:
   publish-homebrew:
     name: Publish to Homebrew
     needs: [detect, build, finalize]
+    # `always()` with every predecessor named, because the skip from a
+    # deliberately absent binary matrix propagates down the whole graph —
+    # even past jobs that ran via `always()` themselves. Without this the
+    # `skip_binaries` bypass builds and drafts a release and then publishes
+    # nothing, which is worse than failing.
     if: >-
-      needs.detect.outputs.proceed == 'true'
+      always()
+      && needs.detect.outputs.proceed == 'true'
       && needs.detect.outputs.dry_run == 'false'
       && needs.detect.outputs.dist_tag == 'latest'
+      && needs.build.result == 'success'
+      && needs.finalize.result == 'success'
     runs-on: ubuntu-latest
     timeout-minutes: 25
     environment: packaging
@@ -1651,10 +1716,18 @@ jobs:
   publish-scoop:
     name: Publish to Scoop
     needs: [detect, build, finalize]
+    # `always()` with every predecessor named, because the skip from a
+    # deliberately absent binary matrix propagates down the whole graph —
+    # even past jobs that ran via `always()` themselves. Without this the
+    # `skip_binaries` bypass builds and drafts a release and then publishes
+    # nothing, which is worse than failing.
     if: >-
-      needs.detect.outputs.proceed == 'true'
+      always()
+      && needs.detect.outputs.proceed == 'true'
       && needs.detect.outputs.dry_run == 'false'
       && needs.detect.outputs.dist_tag == 'latest'
+      && needs.build.result == 'success'
+      && needs.finalize.result == 'success'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     environment: packaging
@@ -1693,11 +1766,19 @@ jobs:
   publish-chocolatey:
     name: Publish to Chocolatey
     needs: [detect, build, finalize]
+    # `always()` with every predecessor named, because the skip from a
+    # deliberately absent binary matrix propagates down the whole graph —
+    # even past jobs that ran via `always()` themselves. Without this the
+    # `skip_binaries` bypass builds and drafts a release and then publishes
+    # nothing, which is worse than failing.
     if: >-
-      needs.detect.outputs.proceed == 'true'
+      always()
+      && needs.detect.outputs.proceed == 'true'
       && needs.detect.outputs.dry_run == 'false'
       && needs.detect.outputs.dist_tag == 'latest'
       && vars.PUBLISH_CHOCOLATEY == 'true'
+      && needs.build.result == 'success'
+      && needs.finalize.result == 'success'
     runs-on: windows-latest
     timeout-minutes: 30
     environment: packaging
@@ -1775,11 +1856,19 @@ jobs:
   publish-winget:
     name: Publish to WinGet
     needs: [detect, build, finalize]
+    # `always()` with every predecessor named, because the skip from a
+    # deliberately absent binary matrix propagates down the whole graph —
+    # even past jobs that ran via `always()` themselves. Without this the
+    # `skip_binaries` bypass builds and drafts a release and then publishes
+    # nothing, which is worse than failing.
     if: >-
-      needs.detect.outputs.proceed == 'true'
+      always()
+      && needs.detect.outputs.proceed == 'true'
       && needs.detect.outputs.dry_run == 'false'
       && needs.detect.outputs.dist_tag == 'latest'
       && vars.PUBLISH_WINGET == 'true'
+      && needs.build.result == 'success'
+      && needs.finalize.result == 'success'
     runs-on: windows-latest
     timeout-minutes: 30
     environment: packaging
@@ -1865,11 +1954,19 @@ jobs:
   publish-aur:
     name: Publish to the AUR
     needs: [detect, build, finalize]
+    # `always()` with every predecessor named, because the skip from a
+    # deliberately absent binary matrix propagates down the whole graph —
+    # even past jobs that ran via `always()` themselves. Without this the
+    # `skip_binaries` bypass builds and drafts a release and then publishes
+    # nothing, which is worse than failing.
     if: >-
-      needs.detect.outputs.proceed == 'true'
+      always()
+      && needs.detect.outputs.proceed == 'true'
       && needs.detect.outputs.dry_run == 'false'
       && needs.detect.outputs.dist_tag == 'latest'
       && vars.PUBLISH_AUR == 'true'
+      && needs.build.result == 'success'
+      && needs.finalize.result == 'success'
     runs-on: ubuntu-latest
     timeout-minutes: 20
     environment: packaging

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Unreleased changes appear first and represent commits that have not yet been inc
 > Changes merged since the last versioned release that have not yet shipped in a tagged version.
 
 ### Fixed
+- Fixed the operator bypass that skips the standalone binaries, which could not have produced a release. It exists so a runner-class outage cannot strand a security fix, and it had never been run. Running it showed that skipping the binary builds also skipped every job after them — artefact verification on all three platforms, the read-only install check, the draft, and then every publish — so the emergency path would have produced nothing at all. Both halves are fixed, and a release with binaries skipped now builds, verifies and drafts exactly as a normal one does.
 - Corrected the command shown for checking a download against `checksums.sha256`. The file lists every asset a release publishes, so `sha256sum -c checksums.sha256` reports the eight you did not download as `FAILED open or read` and exits non-zero — which reads as a corrupted release and is not one. The documented command now checks the one file you actually have, and works the same way on macOS, where `shasum` has no flag for skipping the rest.
 
 ## 0.5.4 (2026-08-14)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ Unreleased changes appear first and represent commits that have not yet been inc
 
 > Changes merged since the last versioned release that have not yet shipped in a tagged version.
 
+### Fixed
+- Corrected the command shown for checking a download against `checksums.sha256`. The file lists every asset a release publishes, so `sha256sum -c checksums.sha256` reports the eight you did not download as `FAILED open or read` and exits non-zero — which reads as a corrupted release and is not one. The documented command now checks the one file you actually have, and works the same way on macOS, where `shasum` has no flag for skipping the rest.
+
 ## 0.5.4 (2026-08-14)
 
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,6 +44,8 @@ Keep documentation updated with behavior changes. Published documentation lives 
 
 For user-visible changes, add a concise entry under `## Unreleased` in `CHANGELOG.md`. Use the existing Summary and Detailed Changes structure. Documentation changes should be submitted to the website repository as a companion update when relevant.
 
+**When a release changes an install path, a command, a flag or a channel, the website repository ships in the same batch.** The published documentation lives in `looptroop-ai/LoopTroop-Website`, so nothing in this repository's CI can notice when it falls behind — and it did, for four releases, while every page still opened with `git clone` and `npm run dev`. Two automated guards now catch part of it (`verify:site` requires Getting Started to lead with an install command, and `sync:cli --check` fails when the CLI reference drifts from `USAGE`), but neither knows about a new channel or a changed flag. That is what this line is for. Bumping `CLI_SOURCE_REF` in the website's `scripts/sync-cli-reference.mjs` to the new tag, and re-running `npm run sync:cli`, is part of shipping a release.
+
 ## Issues
 
 Before opening an issue, please check whether a similar issue already exists.

--- a/README.md
+++ b/README.md
@@ -189,27 +189,23 @@ review gates.
 
 ### Or use a package manager
 
-| | Install | Upgrade | |
-|---|---|---|---|
-| **npm** (everywhere) | `npm install -g looptroop` | `npm install -g looptroop@latest` | ✅ |
-| **bun** (everywhere) | `bun add -g looptroop` | `bun add -g looptroop@latest` | ✅ |
-| **pnpm** (everywhere) | `pnpm add -g looptroop` | `pnpm add -g looptroop@latest` | ✅ |
-| **Homebrew** (macOS, Linux) | `brew install looptroop-ai/tap/looptroop` | `brew upgrade looptroop` | ✅ |
-| **Scoop** (Windows) | `scoop bucket add looptroop https://github.com/looptroop-ai/scoop-bucket`<br>`scoop install looptroop` | `scoop update looptroop` | ✅ |
-| **Docker** | `docker pull looptroopai/looptroop:latest` | `docker pull looptroopai/looptroop:latest` | ✅ |
-| **Chocolatey** (Windows) | `choco install looptroop` | `choco upgrade looptroop` | ⏳ |
-| **WinGet** (Windows) | `winget install LoopTroopAI.LoopTroop` | `looptroop stop`<br>`winget upgrade LoopTroopAI.LoopTroop` | ⏳ |
-| **AUR** (Arch Linux) | `yay -S looptroop-bin` | `yay -Syu looptroop-bin` | ⏳ |
+| | Install | Upgrade |
+|---|---|---|
+| **npm** (everywhere) | `npm install -g looptroop` | `npm install -g looptroop@latest` |
+| **bun** (everywhere) | `bun add -g looptroop` | `bun add -g looptroop@latest` |
+| **pnpm** (everywhere) | `pnpm add -g looptroop` | `pnpm add -g looptroop@latest` |
+| **Homebrew** (macOS, Linux) | `brew install looptroop-ai/tap/looptroop` | `brew upgrade looptroop` |
+| **Scoop** (Windows) | `scoop bucket add looptroop https://github.com/looptroop-ai/scoop-bucket`<br>`scoop install looptroop` | `scoop update looptroop` |
+| **Docker** | `docker pull looptroopai/looptroop:latest` | `docker pull looptroopai/looptroop:latest` |
 
-⏳ **means the command does not work yet.** Those three packages are built and
-tested on every change, and each is waiting on somebody else: Chocolatey on
-community moderation, WinGet on a pull request being reviewed at Microsoft, and
-the AUR on registration reopening after a security incident. The commands are
-listed because they are what will work, unchanged, the day each clears. Until
-then, every ✅ row is a real alternative on the same platform.
+LoopTroop is also packaged for **Chocolatey**, **WinGet** and the **AUR**. Those
+three are built and tested on every change but are not published yet, each
+waiting on somebody else's queue, so their commands do not work today.
 
-The current state of all three, and everything below in more detail, is on the
-[Installation](https://www.looptroop.ovh/docs/installation) page.
+**[The Installation page](https://www.looptroop.ovh/docs/installation) is the
+one place that tracks which channels are live.** It is deliberately not repeated
+here: two copies of a status that can change in a week is how one of them ends
+up lying.
 
 `looptroop doctor` tells you which of these your copy came from and the exact
 command that upgrades it — and each manager is given *its own* upgrade command,
@@ -242,15 +238,26 @@ what WinGet installs, and why that channel declares no Node dependency.
 Each archive is listed in the release's `release-manifest.json` with its
 checksum, and carries a build provenance attestation. Every release also
 publishes `checksums.sha256`, so you can check a download with the tool you
-already have:
+already have. It lists every asset the release publishes, so check the line for
+the one you downloaded rather than the whole file:
 
 ```bash
-sha256sum -c checksums.sha256        # shasum -a 256 -c on macOS
+grep looptroop-<version>-linux-x64.tar.gz checksums.sha256 | sha256sum -c
+```
+
+```bash
+grep looptroop-<version>-darwin-arm64.tar.gz checksums.sha256 | shasum -a 256 -c
 ```
 
 ```powershell
 Get-FileHash looptroop-<version>-win-x64.zip -Algorithm SHA256
 ```
+
+A plain `sha256sum -c checksums.sha256` reports every asset you did *not*
+download as `FAILED open or read` and exits non-zero, which looks like a bad
+release and is not one. GNU coreutils can be told to skip them with
+`sha256sum --ignore-missing -c checksums.sha256`; macOS `shasum` has no such
+flag, which is why the single-line form above is the one that works everywhere.
 
 Intel Macs are not among the binaries: Node cannot build a single-file
 executable for that target, so use Homebrew or npm there.


### PR DESCRIPTION
Three follow-ups from a review round, one of them user-facing and wrong in a way that would generate bug reports.

## The checksum command does not work

`checksums.sha256` lists all nine assets a release publishes. Nobody downloads nine. So `sha256sum -c checksums.sha256` — what the README and the installation page both told people to run — does this against the real 0.5.4 release:

```
sha256sum: install.sh: No such file or directory
install.sh: FAILED open or read
looptroop-0.5.4.tgz: OK
sha256sum: looptroop-0.5.4-linux-arm64.tar.gz: No such file or directory
...
sha256sum: WARNING: 7 listed files could not be read
exit=1
```

Somebody verifying their Windows zip sees seven FAILED lines and a non-zero exit, and concludes the release is bad. It is fine.

It was hiding in plain sight: the only time that file had ever been checked was my own verification, which happened to `grep` a subset into a temp file first — working around the bug without noticing it.

Documented now as checking the line for the file you actually have, which behaves identically on macOS. `--ignore-missing` is mentioned as the GNU shortcut but deliberately not the primary form, because macOS `shasum` does not have it.

## One channel-status table, not two

The README and the installation page both carried the full matrix with ⏳ markers. When WinGet merges upstream, one flips and the other keeps telling people a command works that does not — the exact drift this phase existed to remove, on a different string. The README now lists the stable channels and points at the installation page as the single place tracking availability.

## CONTRIBUTING

Adds the release-checklist line that was specified and never written: when a release changes an install path, a command, a flag or a channel, the website repository ships in the same batch — including bumping `CLI_SOURCE_REF` to the new tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)