### PR TITLE
fix(ci): stop executing a mutable installer, and move off Node-20 artifact actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -360,14 +360,32 @@ jobs:
         if: matrix.manager != 'bun' || runner.os != 'Windows'
         run: npm install -g ${{ matrix.manager == 'bun' && 'bun@1.3.14' || 'pnpm@11.21.0' }}
 
-      - name: Install bun from its own installer
+      # The release archive, checked against the digest bun published for it,
+      # rather than piping bun.sh/install.ps1 into a shell. That script is
+      # fetched live and executed with no integrity check, so pinning the
+      # version it installs still leaves the installer itself mutable — which is
+      # the one thing every other download in this repository refuses to do.
+      - name: Install bun from a verified archive
         if: matrix.manager == 'bun' && runner.os == 'Windows'
         shell: pwsh
+        env:
+          BUN_VERSION: 1.3.14
+          BUN_SHA256: 0a0620930b6675d7ba440e81f4e0e00d3cfbe096c4b140d3fff02205e9e18922
         run: |
           $ErrorActionPreference = 'Stop'
-          & ([scriptblock]::Create((irm https://bun.sh/install.ps1))) -Version 1.3.14
-          # The installer does not touch this job's PATH, only the user's.
-          "$env:USERPROFILE\.bun\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+          $zip = Join-Path $env:RUNNER_TEMP 'bun-windows-x64.zip'
+          $dest = Join-Path $env:RUNNER_TEMP 'bun'
+          Invoke-WebRequest -UseBasicParsing -Uri "https://github.com/oven-sh/bun/releases/download/bun-v$env:BUN_VERSION/bun-windows-x64.zip" -OutFile $zip
+          $actual = (Get-FileHash -Path $zip -Algorithm SHA256).Hash.ToLower()
+          if ($actual -ne $env:BUN_SHA256) {
+            throw "bun-windows-x64.zip digest mismatch: expected $env:BUN_SHA256, got $actual"
+          }
+          Expand-Archive -Path $zip -DestinationPath $dest -Force
+          # The archive nests the executable one directory down.
+          $bin = (Get-ChildItem -Path $dest -Filter bun.exe -Recurse | Select-Object -First 1).Directory.FullName
+          if (-not $bin) { throw "bun.exe not found under $dest" }
+          $bin | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+          & (Join-Path $bin 'bun.exe') --version
 
       - name: Install globally with ${{ matrix.manager }} and check what it reports
         run: node scripts/smoke-node-manager.mjs ${{ matrix.manager }}
@@ -421,7 +439,7 @@ jobs:
           done
 
       - name: Upload the bundle
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: bundle
           path: |
@@ -450,7 +468,7 @@ jobs:
           node-version: 24.15.0
 
       - name: Download the bundle
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: bundle
           path: ${{ runner.temp }}/bundle
@@ -507,7 +525,7 @@ jobs:
           node-version: 24.15.0
 
       - name: Download the bundle
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: bundle
           path: ${{ runner.temp }}/bundle
@@ -578,7 +596,7 @@ jobs:
           node-version: 24.15.0
 
       - name: Download the bundle
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: bundle
           path: ${{ runner.temp }}/bundle
@@ -689,7 +707,7 @@ jobs:
           node scripts/smoke-binary-install.mjs --archive "${archive}"
 
       - name: Upload the archive
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: binary-${{ matrix.target }}
           path: |
@@ -721,7 +739,7 @@ jobs:
           node-version: 24.15.0
 
       - name: Download the Windows binary
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: binary-win-x64
           path: ${{ runner.temp }}/binary
@@ -856,7 +874,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Download the bundle
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: bundle
           path: ${{ runner.temp }}/bundle

--- a/.github/workflows/container-republish.yml
+++ b/.github/workflows/container-republish.yml
@@ -228,7 +228,7 @@ jobs:
       # both workflows feed the container build from an identically named
       # artefact.
       - name: Upload the artefact for the build legs
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: release-artefacts
           path: |
@@ -274,7 +274,7 @@ jobs:
         run: node scripts/pin-npm.mjs
 
       - name: Download the release artefacts
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: release-artefacts
 
@@ -377,7 +377,7 @@ jobs:
           done
 
       - name: Upload the digest
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: container-digest-${{ matrix.arch }}
           path: digest-${{ matrix.arch }}.txt
@@ -423,7 +423,7 @@ jobs:
           node-version: 24.15.0
 
       - name: Download the digests
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           pattern: container-digest-*
           merge-multiple: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -292,7 +292,7 @@ jobs:
             ${{ runner.temp }}/binary/*.zip
 
       - name: Upload the archive
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: release-binary-${{ matrix.target }}
           path: |
@@ -383,7 +383,7 @@ jobs:
       # are all part of one release.
       - name: Collect the standalone binaries
         if: needs.detect.outputs.skip_binaries != 'true'
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           pattern: release-binary-*
           merge-multiple: true
@@ -458,7 +458,7 @@ jobs:
           '
 
       - name: Upload the release artefacts
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: release-artefacts
           path: |
@@ -515,7 +515,7 @@ jobs:
         run: node scripts/pin-npm.mjs
 
       - name: Download the release artefacts
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: release-artefacts
 
@@ -567,7 +567,7 @@ jobs:
         run: node scripts/pin-npm.mjs
 
       - name: Download the release artefacts
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: release-artefacts
 
@@ -629,7 +629,7 @@ jobs:
         run: node scripts/pin-npm.mjs
 
       - name: Download the release artefacts
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: release-artefacts
 
@@ -765,7 +765,7 @@ jobs:
           npm --version
 
       - name: Download the release artefacts
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: release-artefacts
 
@@ -1024,7 +1024,7 @@ jobs:
           fetch-depth: 0
 
       - name: Download the release artefacts
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: release-artefacts
 
@@ -1141,7 +1141,7 @@ jobs:
         run: node scripts/pin-npm.mjs
 
       - name: Download the release artefacts
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: release-artefacts
 
@@ -1286,7 +1286,7 @@ jobs:
       # Per architecture, because the legs of a matrix share one `outputs` map
       # and the last leg to finish would be the only one whose digest survived.
       - name: Upload the digest
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: container-digest-${{ matrix.arch }}
           path: digest-${{ matrix.arch }}.txt
@@ -1350,7 +1350,7 @@ jobs:
       # `merge-multiple` because the two legs uploaded one file each under
       # different artefact names; this flattens both into the working directory.
       - name: Download the digests
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           pattern: container-digest-*
           merge-multiple: true
@@ -1668,7 +1668,7 @@ jobs:
           node-version: 24.15.0
 
       - name: Download the release artefacts
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: release-artefacts
 
@@ -1743,7 +1743,7 @@ jobs:
           node-version: 24.15.0
 
       - name: Download the release artefacts
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: release-artefacts
 
@@ -1796,7 +1796,7 @@ jobs:
           node-version: 24.15.0
 
       - name: Download the release artefacts
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: release-artefacts
 
@@ -1886,7 +1886,7 @@ jobs:
           node-version: 24.15.0
 
       - name: Download the release artefacts
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: release-artefacts
 
@@ -1984,7 +1984,7 @@ jobs:
           node-version: 24.15.0
 
       - name: Download the release artefacts
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: release-artefacts
 


### PR DESCRIPTION
Two review findings, both confirmed against this repository before acting.

## 1. The Windows bun step executed mutable remote code

`ci.yml` piped `bun.sh/install.ps1` straight into a shell. `-Version 1.3.14` pinned what it *installed*, but not the installer itself — that was fetched live and executed with no integrity check, in a repository that pins every action by commit SHA and attests its own artefacts.

It now downloads `bun-windows-x64.zip` from the pinned release and checks it against the digest bun published (`0a06209…8922`) before extracting. This keeps the `EBUSY` race fixed — the reason the step existed — without the remote-execution hole.

## 2. Artifact actions are several majors behind and target Node 20

| Action | Was | Now |
|---|---|---|
| `actions/upload-artifact` | v4.6.2 | **v7.0.1** |
| `actions/download-artifact` | v4.3.0 | **v8.0.1** |

Not theoretical — the 0.5.5 release run emitted this once per uploading job:

```
##[warning]Node.js 20 is deprecated. The following actions target Node.js 20
but are being forced to run on Node.
```

21 call sites across `ci.yml`, `release.yml` and `container-republish.yml`, all pinned by commit SHA.

## Risk, and how it gets covered

`download-artifact` moves v4 → v8, which is a big jump. CI exercises the artifact round trip (bundle, binaries, container), but the **release** workflow's use is only fully exercised during a release. So this needs a release dry-run rehearsal on a bump branch before it is trusted, not just green CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)