### PR TITLE
Fix Tailscale and LAN ticket creation in development

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ Unreleased changes appear first and represent commits that have not yet been inc
 
 > Changes merged since the last versioned release that have not yet shipped in a tagged version.
 
+### Summary
+- Remote development works from the advertised LAN and trusted Tailscale URLs again, including ticket creation and every other write action.
+
+### Fixed
+- Fixed development API writes failing with `Forbidden: cross-origin requests are not accepted` when the interface was opened through a LAN address or a trusted same-origin reverse proxy such as Tailscale Serve. Vite now translates the browser-visible origin only when the browser vouches that the request is same-origin and that origin exactly matches the incoming frontend host. Requests from unrelated pages keep their original origin and remain blocked by the backend guard; the production daemon and its loopback-only boundary are unchanged.
+
 ## 0.5.5 (2026-08-14)
 
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -44,6 +44,15 @@ Binding LoopTroop to a non-loopback address requires both
 start otherwise. Doing so exposes a control-plane API that can execute commands
 in your repositories, and it is not a supported configuration.
 
+The opt-in development LAN mode is narrower: Vite may be reachable from a
+trusted network while the API and OpenCode remain on loopback. When another
+trusted proxy terminates the frontend origin before Vite, the development proxy
+translates that origin for the loopback API hop only if the browser marks the
+request as same-origin and its `Origin` authority exactly matches the incoming
+frontend `Host`. An unrelated page fails those checks and reaches the API host
+guard unchanged. This development path does not make exposing the installed
+daemon a supported configuration.
+
 Reports that describe LoopTroop running commands or modifying repositories you
 attached to it are describing intended behaviour. Reports that describe a way to
 escape those boundaries — reaching outside attached repositories, escalating

--- a/scripts/dev-api-proxy.ts
+++ b/scripts/dev-api-proxy.ts
@@ -1,0 +1,55 @@
+export interface DevProxyOriginInput {
+  origin: string | undefined
+  host: string | undefined
+  secFetchSite: string | undefined
+  backendOrigin: string
+}
+
+function parseHttpOrigin(value: string): URL | null {
+  try {
+    const parsed = new URL(value)
+    if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') return null
+    return parsed
+  } catch {
+    return null
+  }
+}
+
+function hostMatchesOrigin(host: string, origin: URL): boolean {
+  const trimmed = host.trim()
+  if (!trimmed || /[\s/@]/.test(trimmed)) return false
+
+  try {
+    // Parsing the Host header under the browser-visible scheme gives both sides
+    // the same default-port rules while retaining explicit non-default ports.
+    return new URL(`${origin.protocol}//${trimmed}`).host === origin.host
+  } catch {
+    return false
+  }
+}
+
+/**
+ * Returns the Origin Vite should present on its loopback API hop, or null when
+ * the browser request must reach the backend unchanged.
+ *
+ * A remote browser still makes a same-origin request to Vite, but a reverse
+ * proxy such as Tailscale Serve terminates that public origin before Vite sends
+ * the request to LoopTroop's loopback backend. The browser-controlled Origin
+ * therefore no longer matches the rewritten Host unless this trusted proxy hop
+ * normalizes it.
+ *
+ * Both checks are required. `Sec-Fetch-Site` is a browser-forbidden header that
+ * vouches for same-origin, while matching Origin to the incoming Host prevents
+ * an unrelated page from having its cross-origin request normalized. Requests
+ * that fail either check keep their real Origin so the backend host guard can
+ * reject them.
+ */
+export function getDevProxyOriginOverride(input: DevProxyOriginInput): string | null {
+  if (input.secFetchSite?.trim().toLowerCase() !== 'same-origin') return null
+  if (!input.origin || !input.host) return null
+
+  const origin = parseHttpOrigin(input.origin)
+  if (origin === null || !hostMatchesOrigin(input.host, origin)) return null
+
+  return parseHttpOrigin(input.backendOrigin)?.origin ?? null
+}

--- a/tests/dev-api-proxy.test.ts
+++ b/tests/dev-api-proxy.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from 'vitest'
+import { getDevProxyOriginOverride } from '../scripts/dev-api-proxy'
+
+describe('getDevProxyOriginOverride', () => {
+  const backendOrigin = 'http://127.0.0.1:3000'
+
+  it.each([
+    {
+      label: 'the HTTPS Tailscale development URL',
+      origin: 'https://devbox.example-tailnet.ts.net:8443',
+      host: 'devbox.example-tailnet.ts.net:8443',
+    },
+    {
+      label: 'an HTTP LAN development URL',
+      origin: 'http://192.168.1.42:5173',
+      host: '192.168.1.42:5173',
+    },
+  ])('rewrites $label when the browser reports same-origin', ({ origin, host }) => {
+    expect(getDevProxyOriginOverride({
+      origin,
+      host,
+      secFetchSite: 'same-origin',
+      backendOrigin,
+    })).toBe(backendOrigin)
+  })
+
+  it('compares DNS authorities case-insensitively', () => {
+    expect(getDevProxyOriginOverride({
+      origin: 'https://DEVBOX.EXAMPLE-TAILNET.TS.NET:8443',
+      host: 'devbox.example-tailnet.ts.net:8443',
+      secFetchSite: 'same-origin',
+      backendOrigin,
+    })).toBe(backendOrigin)
+  })
+
+  it.each([
+    {
+      label: 'cross-site fetch metadata',
+      origin: 'https://attacker.example',
+      host: 'devbox.example-tailnet.ts.net:8443',
+      secFetchSite: 'cross-site',
+    },
+    {
+      label: 'same-site fetch metadata',
+      origin: 'https://devbox.example-tailnet.ts.net:8443',
+      host: 'devbox.example-tailnet.ts.net:8443',
+      secFetchSite: 'same-site',
+    },
+    {
+      label: 'an unrelated origin despite same-origin fetch metadata',
+      origin: 'https://attacker.example',
+      host: 'devbox.example-tailnet.ts.net:8443',
+      secFetchSite: 'same-origin',
+    },
+    {
+      label: 'a mismatched port',
+      origin: 'https://devbox.example-tailnet.ts.net:8443',
+      host: 'devbox.example-tailnet.ts.net:5173',
+      secFetchSite: 'same-origin',
+    },
+    {
+      label: 'a malformed origin',
+      origin: 'not a URL',
+      host: 'devbox.example-tailnet.ts.net:8443',
+      secFetchSite: 'same-origin',
+    },
+    {
+      label: 'an opaque origin',
+      origin: 'null',
+      host: 'devbox.example-tailnet.ts.net:8443',
+      secFetchSite: 'same-origin',
+    },
+    {
+      label: 'missing fetch metadata',
+      origin: 'https://devbox.example-tailnet.ts.net:8443',
+      host: 'devbox.example-tailnet.ts.net:8443',
+      secFetchSite: undefined,
+    },
+    {
+      label: 'a missing origin',
+      origin: undefined,
+      host: 'devbox.example-tailnet.ts.net:8443',
+      secFetchSite: 'same-origin',
+    },
+    {
+      label: 'a missing host',
+      origin: 'https://devbox.example-tailnet.ts.net:8443',
+      host: undefined,
+      secFetchSite: 'same-origin',
+    },
+  ])('does not rewrite $label', ({ origin, host, secFetchSite }) => {
+    expect(getDevProxyOriginOverride({
+      origin,
+      host,
+      secFetchSite,
+      backendOrigin,
+    })).toBeNull()
+  })
+})

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -13,6 +13,7 @@ import {
   FRONTEND_DEDUPED_DEPENDENCIES,
   frontendOptimizeDeps,
 } from './scripts/vite-optimize-deps'
+import { getDevProxyOriginOverride } from './scripts/dev-api-proxy'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
 const backendOrigin = getBackendOrigin()
@@ -199,9 +200,19 @@ export default defineConfig({
         target: backendOrigin,
         changeOrigin: true,
         configure: (proxy) => {
-          proxy.on('proxyReq', (proxyReq) => {
+          proxy.on('proxyReq', (proxyReq, req) => {
             if (apiToken) {
               proxyReq.setHeader(apiTokenHeader, apiToken)
+            }
+
+            const originOverride = getDevProxyOriginOverride({
+              origin: req.headers.origin,
+              host: req.headers.host,
+              secFetchSite: req.headers['sec-fetch-site'],
+              backendOrigin,
+            })
+            if (originOverride) {
+              proxyReq.setHeader('Origin', originOverride)
             }
           })
           proxy.on('error', (err, _req, res) => {


### PR DESCRIPTION
## Summary
- normalize remote frontend origins only across the trusted Vite-to-loopback proxy hop
- require browser-vouched same-origin fetch metadata and an exact Origin/Host authority match
- keep unrelated origins blocked and production daemon handling unchanged
- add focused Tailscale, LAN, malformed-origin, and hostile-origin coverage
- update the security policy, changelog, and published website documentation

## Impact
All development UI writes through a same-origin LAN or Tailscale-served frontend work again, including ticket creation. Installed daemon behavior is unchanged.

## Verification
- npm run lint
- npm run typecheck
- npm run build
- npm test (289 files passed; 3,323 passed, 3 skipped)
- live browser-shaped POST through the configured Tailscale :8443 URL reaches ticket validation
- same endpoint with a mismatched attacker Origin remains 403
- website: npm run docs:build
- website: npm test
- website: npm run verify:site
- website: npm run licenses:check