### PR TITLE
Surface release updates across CLI and UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,15 @@ Unreleased changes appear first and represent commits that have not yet been inc
 
 ### Summary
 - Remote development works from the advertised LAN and trusted Tailscale URLs again, including ticket creation and every other write action.
+- New releases are now visible wherever users naturally look: the core CLI commands, Doctor, the header version, and an install-aware About window with full GitHub release notes.
+
+### Added
+- Added one shared published-release status for the CLI and interface. `looptroop --version`, `status`, `start`, and `open` now print a notice whenever a newer GitHub release exists; `doctor` always reports the current and latest known versions, and both `status --json` and `doctor --json` expose the same structured update facts without adding non-JSON output.
+- Added an Updates section to About with the current and latest versions, the detected installation channel, exact ordered upgrade commands, restart or container-recreation guidance, and a Changelog control whose hover/focus card shows the complete latest GitHub release body. The header version now opens About and gains a quiet monochrome update icon only when a newer release is available.
+
+### Changed
+- Release discovery now follows the latest published GitHub release rather than npm alone, so the version users are shown has public release notes and is not announced while its GitHub release is still a draft. Results and failed attempts are cached for 15 minutes so each requested command can report updates without repeatedly waiting on GitHub when offline.
+- Upgrade guidance now includes what happens after package replacement: ordinary package-manager and source installations restart the daemon to load the new code, the transactional standalone installer explains that it handles the restart itself, WinGet opens LoopTroop after replacing the stopped executable, and containers explicitly require recreation after pulling the image.
 
 ### Fixed
 - Fixed development API writes failing with `Forbidden: cross-origin requests are not accepted` when the interface was opened through a LAN address or a trusted same-origin reverse proxy such as Tailscale Serve. Vite now translates the browser-visible origin only when the browser vouches that the request is same-origin and that origin exactly matches the incoming frontend host. Requests from unrelated pages keep their original origin and remain blocked by the backend guard; the production daemon and its loopback-only boundary are unchanged.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ Unreleased changes appear first and represent commits that have not yet been inc
 - New releases are now visible wherever users naturally look: the core CLI commands, Doctor, the header version, and an install-aware About window with full GitHub release notes.
 
 ### Added
-- Added one shared published-release status for the CLI and interface. `looptroop --version`, `status`, `start`, and `open` now print a notice whenever a newer GitHub release exists; `doctor` always reports the current and latest known versions, and both `status --json` and `doctor --json` expose the same structured update facts without adding non-JSON output.
+- Added one shared published-release status for the CLI and interface. `looptroop --version`, `status`, `start`, and `open` now report a notice on **stderr** whenever a newer GitHub release exists, leaving stdout byte-for-byte as it was so scripts that read `looptroop --version` keep working; `doctor` always reports the current and latest known versions, and both `status --json` and `doctor --json` expose the same structured update facts without adding non-JSON output.
 - Added an Updates section to About with the current and latest versions, the detected installation channel, exact ordered upgrade commands, restart or container-recreation guidance, and a Changelog control whose hover/focus card shows the complete latest GitHub release body. The header version now opens About and gains a quiet monochrome update icon only when a newer release is available.
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -206,6 +206,22 @@ place that tracks which channels are live**, and covers upgrading, uninstalling,
 verifying a download against the checksums each release publishes, and running in
 a container.
 
+### Finding and applying updates
+
+`looptroop --version`, `looptroop status`, `looptroop doctor`, `looptroop start`
+and `looptroop open` all tell you when a newer published GitHub release exists.
+`doctor` always shows the current and latest known versions and names the exact
+upgrade command for the channel that installed this copy. In the interface, the
+version beside the LoopTroop title opens **About**; a small monochrome update icon
+appears there when a newer release is available. About includes the ordered
+upgrade steps and the complete GitHub release notes under **Changelog**.
+
+After upgrading an npm, bun, pnpm, Yarn, Homebrew, Scoop, Chocolatey, AUR or
+source installation, run `looptroop restart` so an existing daemon loads the new
+files. The standalone installer handles that restart transactionally. For a
+container, pulling a new image is not enough: recreate the container with the
+same volumes, ports and environment settings.
+
 ### What you need besides LoopTroop
 
 - **git**, and **`gh`** authenticated, for the pull-request step at the end of a

--- a/server/cli/__tests__/cliUpdate.test.ts
+++ b/server/cli/__tests__/cliUpdate.test.ts
@@ -37,13 +37,19 @@ const update = {
 
 describe('CLI update surfaces', () => {
   let stdout = ''
+  let stderr = ''
 
   beforeEach(() => {
     stdout = ''
+    stderr = ''
     vi.clearAllMocks()
     mocks.getUpdateStatus.mockResolvedValue(update)
     vi.spyOn(process.stdout, 'write').mockImplementation((chunk: string | Uint8Array) => {
       stdout += typeof chunk === 'string' ? chunk : Buffer.from(chunk).toString()
+      return true
+    })
+    vi.spyOn(process.stderr, 'write').mockImplementation((chunk: string | Uint8Array) => {
+      stderr += typeof chunk === 'string' ? chunk : Buffer.from(chunk).toString()
       return true
     })
   })
@@ -54,11 +60,25 @@ describe('CLI update surfaces', () => {
     ['--version'],
     ['start'],
     ['open'],
-  ])('checks and displays an available update for looptroop %s', async (argument) => {
+  ])('checks and reports an available update for looptroop %s', async (argument) => {
     await main([argument])
 
     expect(mocks.getUpdateStatus).toHaveBeenCalledWith({ currentVersion: APP_VERSION })
-    expect(stdout).toContain('UPDATE AVAILABLE')
+    expect(stderr).toContain('UPDATE AVAILABLE')
+  })
+
+  /**
+   * The installer verifies an install by comparing `looptroop --version` on
+   * stdout to the version it meant to install (`scripts/installer-core.mjs`),
+   * and six release smokes do the same. A notice on stdout turns a healthy
+   * install into a reported failure, so the assertion is exact equality rather
+   * than "contains the version".
+   */
+  it('prints nothing but the version on stdout, even when an update exists', async () => {
+    await main(['--version'])
+
+    expect(stdout).toBe(`${APP_VERSION}\n`)
+    expect(stderr).toContain('UPDATE AVAILABLE')
   })
 
   it('passes update facts into status and preserves JSON-only output', async () => {
@@ -66,25 +86,63 @@ describe('CLI update surfaces', () => {
 
     expect(mocks.statusCommand).toHaveBeenCalledWith(true, update)
     expect(stdout).not.toContain('UPDATE AVAILABLE')
+    expect(stderr).toBe('')
   })
 
-  it('displays the update after human-readable status output', async () => {
+  /**
+   * The lookup is left pending until the status itself has run. If `main` ever
+   * awaits it first, nothing resolves it and this test times out — which is the
+   * point: a slow or unreachable GitHub must not delay the answer that was
+   * asked for.
+   */
+  it('does not wait on the release lookup before printing human-readable status', async () => {
+    let statusRan = false
+    let resolveUpdate: (value: typeof update) => void = () => undefined
+    mocks.getUpdateStatus.mockReturnValue(new Promise<typeof update>((resolve) => { resolveUpdate = resolve }))
+    mocks.statusCommand.mockImplementation(async () => {
+      statusRan = true
+      resolveUpdate(update)
+      return 0
+    })
+
     await main(['status'])
 
-    expect(mocks.statusCommand).toHaveBeenCalledWith(false, update)
-    expect(stdout).toContain('UPDATE AVAILABLE')
+    expect(statusRan).toBe(true)
+    // One argument: the status itself is never handed the update.
+    expect(mocks.statusCommand).toHaveBeenCalledWith(false)
+    expect(stderr).toContain('UPDATE AVAILABLE')
   })
 
-  it('displays the update before a foreground start takes over the terminal', async () => {
+  it('reports the update before a foreground start takes over the terminal', async () => {
     await main(['start', '--foreground'])
 
     expect(mocks.startCommand).toHaveBeenCalledWith({ foreground: true })
-    expect(stdout).toContain('UPDATE AVAILABLE')
+    expect(stderr).toContain('UPDATE AVAILABLE')
   })
 
-  it('passes current and latest versions into doctor for human and JSON output', async () => {
+  /**
+   * The lookup is started before the command it decorates, so a rejection would
+   * arrive as an unhandled rejection — which Node treats as a crash. A failed
+   * release check must cost the notice, never the command.
+   */
+  it.each([
+    ['--version'],
+    ['status'],
+    ['open'],
+    ['doctor'],
+  ])('still runs looptroop %s when the release lookup throws', async (argument) => {
+    mocks.getUpdateStatus.mockRejectedValue(new Error('getaddrinfo ENOTFOUND api.github.com'))
+
+    await expect(main([argument])).resolves.toBe(0)
+    expect(stderr).toBe('')
+  })
+
+  it('hands doctor the lookup unawaited so it overlaps the local checks', async () => {
     await main(['doctor'])
 
-    expect(mocks.doctorCommand).toHaveBeenCalledWith(false, update)
+    const [json, passed] = mocks.doctorCommand.mock.calls[0] as unknown as [boolean, Promise<unknown>]
+    expect(json).toBe(false)
+    expect(passed).toBeInstanceOf(Promise)
+    await expect(passed).resolves.toEqual(update)
   })
 })

--- a/server/cli/__tests__/cliUpdate.test.ts
+++ b/server/cli/__tests__/cliUpdate.test.ts
@@ -1,0 +1,90 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { APP_VERSION } from '../../lib/appVersion'
+
+const mocks = vi.hoisted(() => ({
+  getUpdateStatus: vi.fn(),
+  startCommand: vi.fn(async () => 0),
+  statusCommand: vi.fn(async () => 0),
+  openCommand: vi.fn(async () => 0),
+  doctorCommand: vi.fn(async () => 0),
+}))
+
+vi.mock('../../lib/updateCheck', () => ({
+  getUpdateStatus: mocks.getUpdateStatus,
+  formatUpdateStatusNotice: (status: { updateAvailable: boolean }) => status.updateAvailable ? '\nUPDATE AVAILABLE\n' : '',
+}))
+
+vi.mock('../commands', () => ({
+  startCommand: mocks.startCommand,
+  statusCommand: mocks.statusCommand,
+  openCommand: mocks.openCommand,
+}))
+
+vi.mock('../doctorCommand', () => ({ doctorCommand: mocks.doctorCommand }))
+
+import { main } from '../cli'
+
+const update = {
+  currentVersion: APP_VERSION,
+  latestVersion: '0.6.0',
+  updateAvailable: true,
+  checkedAt: '2026-08-16T08:00:00.000Z',
+  installChannel: 'npm' as const,
+  upgradeCommand: 'npm install -g looptroop@latest',
+  postUpgradeCommand: 'looptroop restart',
+  release: null,
+}
+
+describe('CLI update surfaces', () => {
+  let stdout = ''
+
+  beforeEach(() => {
+    stdout = ''
+    vi.clearAllMocks()
+    mocks.getUpdateStatus.mockResolvedValue(update)
+    vi.spyOn(process.stdout, 'write').mockImplementation((chunk: string | Uint8Array) => {
+      stdout += typeof chunk === 'string' ? chunk : Buffer.from(chunk).toString()
+      return true
+    })
+  })
+
+  afterEach(() => vi.restoreAllMocks())
+
+  it.each([
+    ['--version'],
+    ['start'],
+    ['open'],
+  ])('checks and displays an available update for looptroop %s', async (argument) => {
+    await main([argument])
+
+    expect(mocks.getUpdateStatus).toHaveBeenCalledWith({ currentVersion: APP_VERSION })
+    expect(stdout).toContain('UPDATE AVAILABLE')
+  })
+
+  it('passes update facts into status and preserves JSON-only output', async () => {
+    await main(['status', '--json'])
+
+    expect(mocks.statusCommand).toHaveBeenCalledWith(true, update)
+    expect(stdout).not.toContain('UPDATE AVAILABLE')
+  })
+
+  it('displays the update after human-readable status output', async () => {
+    await main(['status'])
+
+    expect(mocks.statusCommand).toHaveBeenCalledWith(false, update)
+    expect(stdout).toContain('UPDATE AVAILABLE')
+  })
+
+  it('displays the update before a foreground start takes over the terminal', async () => {
+    await main(['start', '--foreground'])
+
+    expect(mocks.startCommand).toHaveBeenCalledWith({ foreground: true })
+    expect(stdout).toContain('UPDATE AVAILABLE')
+  })
+
+  it('passes current and latest versions into doctor for human and JSON output', async () => {
+    await main(['doctor'])
+
+    expect(mocks.doctorCommand).toHaveBeenCalledWith(false, update)
+  })
+})

--- a/server/cli/cli.ts
+++ b/server/cli/cli.ts
@@ -1,6 +1,9 @@
 import { parseArgs } from 'node:util'
 import { APP_VERSION } from '../lib/appVersion'
+import { isSea } from '../lib/isSea'
 import { DAEMON_ARGV } from './daemonHandoff'
+import { formatUpdateStatusNotice, getUpdateStatus, type UpdateStatus } from '../lib/updateCheck'
+import { isEntryPoint } from './entryPoint'
 
 /**
  * Exported so the published CLI reference can be generated from it rather than
@@ -34,6 +37,15 @@ Options:
   --version      Print the version
   --help         Print this message
 `
+
+function checkCliUpdate(): Promise<UpdateStatus> {
+  return getUpdateStatus({ currentVersion: APP_VERSION })
+}
+
+async function finishWithUpdate(code: number, update: Promise<UpdateStatus>): Promise<number> {
+  process.stdout.write(formatUpdateStatusNotice(await update))
+  return code
+}
 
 export async function main(argv: string[]): Promise<number> {
   // Before `parseArgs`, and before anything else. Under npm this file is the
@@ -75,7 +87,7 @@ export async function main(argv: string[]): Promise<number> {
 
   if (values.version) {
     process.stdout.write(`${APP_VERSION}\n`)
-    return 0
+    return finishWithUpdate(0, checkCliUpdate())
   }
 
   // Bare invocation prints help rather than doing something unasked.
@@ -99,10 +111,16 @@ export async function main(argv: string[]): Promise<number> {
     }
     case 'start': {
       const { startCommand } = await import('./commands')
-      return startCommand({
+      const update = checkCliUpdate()
+      const options = {
         ...(port === undefined ? {} : { port }),
         ...(values.foreground ? { foreground: true } : {}),
-      })
+      }
+      if (values.foreground) {
+        process.stdout.write(formatUpdateStatusNotice(await update))
+        return startCommand(options)
+      }
+      return finishWithUpdate(await startCommand(options), update)
     }
     case 'stop': {
       const { stopCommand } = await import('./commands')
@@ -114,11 +132,15 @@ export async function main(argv: string[]): Promise<number> {
     }
     case 'status': {
       const { statusCommand } = await import('./commands')
-      return statusCommand(values.json === true)
+      const update = await checkCliUpdate()
+      const code = await statusCommand(values.json === true, update)
+      if (!values.json) process.stdout.write(formatUpdateStatusNotice(update))
+      return code
     }
     case 'open': {
       const { openCommand } = await import('./commands')
-      return openCommand()
+      const update = checkCliUpdate()
+      return finishWithUpdate(await openCommand(), update)
     }
     case 'logs': {
       const { logsCommand } = await import('./logsCommand')
@@ -129,7 +151,8 @@ export async function main(argv: string[]): Promise<number> {
     }
     case 'doctor': {
       const { doctorCommand } = await import('./doctorCommand')
-      return doctorCommand(values.json === true)
+      const update = await checkCliUpdate()
+      return doctorCommand(values.json === true, update)
     }
     case 'clean': {
       const { cleanCommand } = await import('./cleanCommand')
@@ -142,9 +165,14 @@ export async function main(argv: string[]): Promise<number> {
   }
 }
 
-main(process.argv.slice(2))
-  .then((code) => { process.exitCode = code })
-  .catch((error: unknown) => {
-    process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`)
-    process.exitCode = 1
-  })
+// Package-manager installs call `main` from the old-syntax launcher. A source
+// invocation enters this file directly, while a standalone build has no
+// JavaScript entry path at all. The split also lets tests import `main` safely.
+if (isEntryPoint(import.meta.url, process.argv[1]) || isSea()) {
+  main(process.argv.slice(2))
+    .then((code) => { process.exitCode = code })
+    .catch((error: unknown) => {
+      process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`)
+      process.exitCode = 1
+    })
+}

--- a/server/cli/cli.ts
+++ b/server/cli/cli.ts
@@ -38,12 +38,35 @@ Options:
   --help         Print this message
 `
 
-function checkCliUpdate(): Promise<UpdateStatus> {
-  return getUpdateStatus({ currentVersion: APP_VERSION })
+/**
+ * Never rejects. The lookup is a courtesy attached to commands that have their
+ * own job to do, and it is started before that job runs — so a rejection would
+ * otherwise surface as an unhandled rejection, which Node treats as a crash,
+ * turning a clean failure into a stack trace or a working command into a dead
+ * one. `getUpdateStatus` already absorbs network and cache faults; this covers
+ * whatever is left.
+ */
+function checkCliUpdate(): Promise<UpdateStatus | null> {
+  return getUpdateStatus({ currentVersion: APP_VERSION }).catch(() => null)
 }
 
-async function finishWithUpdate(code: number, update: Promise<UpdateStatus>): Promise<number> {
-  process.stdout.write(formatUpdateStatusNotice(await update))
+/**
+ * Notices go to stderr, never stdout.
+ *
+ * `looptroop --version` is parsed with strict equality by the installer's own
+ * post-install check (`scripts/installer-core.mjs`) and by six release smokes.
+ * A notice appended to stdout makes a healthy install report as a broken one —
+ * and it fires exactly when the installed version is behind the latest release,
+ * which is the normal state for a pinned install and for every channel that
+ * publishes after the GitHub tag. npm and gh route their notifiers to stderr
+ * for the same reason.
+ */
+function writeUpdateNotice(update: UpdateStatus | null): void {
+  if (update !== null) process.stderr.write(formatUpdateStatusNotice(update))
+}
+
+async function finishWithUpdate(code: number, update: Promise<UpdateStatus | null>): Promise<number> {
+  writeUpdateNotice(await update)
   return code
 }
 
@@ -117,7 +140,7 @@ export async function main(argv: string[]): Promise<number> {
         ...(values.foreground ? { foreground: true } : {}),
       }
       if (values.foreground) {
-        process.stdout.write(formatUpdateStatusNotice(await update))
+        writeUpdateNotice(await update)
         return startCommand(options)
       }
       return finishWithUpdate(await startCommand(options), update)
@@ -132,9 +155,14 @@ export async function main(argv: string[]): Promise<number> {
     }
     case 'status': {
       const { statusCommand } = await import('./commands')
-      const update = await checkCliUpdate()
-      const code = await statusCommand(values.json === true, update)
-      if (!values.json) process.stdout.write(formatUpdateStatusNotice(update))
+      // Started here, but for human output not awaited until the status itself
+      // has printed: a notice must never obscure the answer that was asked for,
+      // nor delay it when GitHub is slow or unreachable. JSON has to wait, since
+      // the update is part of the document rather than a line after it.
+      const update = checkCliUpdate()
+      if (values.json === true) return statusCommand(true, await update ?? undefined)
+      const code = await statusCommand(false)
+      writeUpdateNotice(await update)
       return code
     }
     case 'open': {
@@ -151,8 +179,10 @@ export async function main(argv: string[]): Promise<number> {
     }
     case 'doctor': {
       const { doctorCommand } = await import('./doctorCommand')
-      const update = await checkCliUpdate()
-      return doctorCommand(values.json === true, update)
+      // Passed unawaited so the release lookup overlaps the local checks. Doctor
+      // reports the version as one of its checks rather than as a trailing
+      // notice, so unlike `status` it does have to resolve before printing.
+      return doctorCommand(values.json === true, checkCliUpdate())
     }
     case 'clean': {
       const { cleanCommand } = await import('./cleanCommand')

--- a/server/cli/commands.ts
+++ b/server/cli/commands.ts
@@ -4,7 +4,7 @@ import { setTimeout as delay } from 'node:timers/promises'
 import { readDaemonState, getDaemonLogPath, getDaemonLogDir, clearDaemonState, clearStaleDaemonState, readDaemonStartFailure, redactDaemonState, type DaemonState } from '../lib/daemonPaths'
 import { resolveAppConfigDir, ensureSecureDir } from '../lib/appConfigDir'
 import { rotateDaemonLog } from '../lib/daemonLog'
-import { checkForUpdate, formatUpdateNotice } from '../lib/updateCheck'
+import type { UpdateStatus } from '../lib/updateCheck'
 import { clearLockOwnedBy, releaseStaleLock } from '../lib/daemonLock'
 import { matchProcess, readProcessStartToken } from '../lib/processIdentity'
 import { daemonArgv } from './daemonHandoff'
@@ -508,7 +508,7 @@ export function describeOpenCodeForStatus(opencode: DaemonState['opencode']): st
   }
 }
 
-export async function statusCommand(json: boolean): Promise<number> {
+export async function statusCommand(json: boolean, update?: UpdateStatus): Promise<number> {
   const configDir = resolveAppConfigDir()
   const state = await readRunningDaemon(configDir)
   // Only meaningful when nothing is running: a live daemon overwrote the record
@@ -522,6 +522,7 @@ export async function statusCommand(json: boolean): Promise<number> {
       running: state !== null,
       daemon: state ? redactDaemonState(state) : null,
       lastStartFailure: failure,
+      ...(update === undefined ? {} : { update }),
     }, null, 2)}\n`)
     return state ? 0 : 1
   }
@@ -544,11 +545,6 @@ export async function statusCommand(json: boolean): Promise<number> {
     `  Uptime:   ${formatDuration(uptimeMs)}\n` +
     `  OpenCode: ${describeOpenCodeForStatus(state.opencode)}\n`,
   )
-
-  // After the status itself, so a notice never obscures the answer that was
-  // asked for, and never blocks it if the registry is slow or unreachable.
-  const notice = await checkForUpdate({ currentVersion: state.version, configDir })
-  if (notice) process.stdout.write(formatUpdateNotice(notice))
 
   return 0
 }

--- a/server/cli/commands.ts
+++ b/server/cli/commands.ts
@@ -4,7 +4,7 @@ import { setTimeout as delay } from 'node:timers/promises'
 import { readDaemonState, getDaemonLogPath, getDaemonLogDir, clearDaemonState, clearStaleDaemonState, readDaemonStartFailure, redactDaemonState, type DaemonState } from '../lib/daemonPaths'
 import { resolveAppConfigDir, ensureSecureDir } from '../lib/appConfigDir'
 import { rotateDaemonLog } from '../lib/daemonLog'
-import type { UpdateStatus } from '../lib/updateCheck'
+import { summarizeUpdateStatus, type UpdateStatus } from '../lib/updateCheck'
 import { clearLockOwnedBy, releaseStaleLock } from '../lib/daemonLock'
 import { matchProcess, readProcessStartToken } from '../lib/processIdentity'
 import { daemonArgv } from './daemonHandoff'
@@ -522,7 +522,7 @@ export async function statusCommand(json: boolean, update?: UpdateStatus): Promi
       running: state !== null,
       daemon: state ? redactDaemonState(state) : null,
       lastStartFailure: failure,
-      ...(update === undefined ? {} : { update }),
+      ...(update === undefined ? {} : { update: summarizeUpdateStatus(update) }),
     }, null, 2)}\n`)
     return state ? 0 : 1
   }

--- a/server/cli/doctorCommand.ts
+++ b/server/cli/doctorCommand.ts
@@ -3,7 +3,7 @@ import { existsSync, accessSync, constants } from 'node:fs'
 import { resolveAppConfigDir } from '../lib/appConfigDir'
 import { resolveSettings, getSettingsPath } from '../lib/appSettings'
 import { resolveInstallInfo } from '../lib/installChannel'
-import type { UpdateStatus } from '../lib/updateCheck'
+import { summarizeUpdateStatus, type UpdateStatus } from '../lib/updateCheck'
 import { probePort } from '../lib/portProbe'
 import { readDaemonStartFailure, type DaemonState } from '../lib/daemonPaths'
 import type { SchemaCompatibility } from '../db/schemaVersion'
@@ -618,16 +618,25 @@ function versionCheck(update: UpdateStatus): Check {
   }
 }
 
-export async function doctorCommand(json: boolean, update?: UpdateStatus): Promise<number> {
+/**
+ * `update` may be a promise so the caller can start the release lookup before
+ * the local checks run and let the two overlap. Awaiting a plain value is
+ * harmless, so direct callers can still pass a resolved status.
+ */
+export async function doctorCommand(
+  json: boolean,
+  update?: UpdateStatus | null | Promise<UpdateStatus | null>,
+): Promise<number> {
   const checks = await runChecks()
-  const displayedChecks = update === undefined ? checks : [versionCheck(update), ...checks]
+  const resolved = (await update) ?? undefined
+  const displayedChecks = resolved === undefined ? checks : [versionCheck(resolved), ...checks]
   const failed = checks.some((check) => check.status === 'fail')
 
   if (json) {
     // Only JSON on stdout, so the output can be piped into a parser.
     process.stdout.write(`${JSON.stringify({
       ok: !failed,
-      ...(update === undefined ? {} : { update }),
+      ...(resolved === undefined ? {} : { update: summarizeUpdateStatus(resolved) }),
       checks: displayedChecks,
     }, null, 2)}\n`)
     return failed ? 1 : 0

--- a/server/cli/doctorCommand.ts
+++ b/server/cli/doctorCommand.ts
@@ -3,6 +3,7 @@ import { existsSync, accessSync, constants } from 'node:fs'
 import { resolveAppConfigDir } from '../lib/appConfigDir'
 import { resolveSettings, getSettingsPath } from '../lib/appSettings'
 import { resolveInstallInfo } from '../lib/installChannel'
+import type { UpdateStatus } from '../lib/updateCheck'
 import { probePort } from '../lib/portProbe'
 import { readDaemonStartFailure, type DaemonState } from '../lib/daemonPaths'
 import type { SchemaCompatibility } from '../db/schemaVersion'
@@ -514,6 +515,9 @@ async function checkLastStart(): Promise<Check> {
 
 function checkInstallChannel(): Check {
   const info = resolveInstallInfo()
+  const steps = [info.upgradeFirst, info.upgradeCommand, info.postUpgradeCommand]
+    .filter((command): command is string => command !== undefined)
+    .join(', then ')
   return info.channel === 'unknown'
     ? {
         name: 'install',
@@ -525,7 +529,7 @@ function checkInstallChannel(): Check {
     : {
         name: 'install',
         status: 'ok',
-        detail: `${info.channel} (upgrade: ${info.upgradeFirst === undefined ? '' : `${info.upgradeFirst}, then `}${info.upgradeCommand})`,
+        detail: `${info.channel} (upgrade: ${steps})${info.upgradeNote ? `; ${info.upgradeNote}` : ''}`,
       }
 }
 
@@ -597,18 +601,40 @@ export async function runChecks(): Promise<Check[]> {
   ]
 }
 
-export async function doctorCommand(json: boolean): Promise<number> {
+function versionCheck(update: UpdateStatus): Check {
+  const latest = update.latestVersion ?? 'unavailable'
+  const detail = `current ${update.currentVersion}; latest ${latest}${update.updateAvailable ? ' (update available)' : ''}`
+  if (!update.updateAvailable) return { name: 'version', status: 'ok', detail }
+
+  const commands = [update.upgradeFirst, update.upgradeCommand, update.postUpgradeCommand]
+    .filter((command): command is string => command !== undefined)
+    .map((command) => `\`${command}\``)
+    .join(', then ')
+  return {
+    name: 'version',
+    status: 'warn',
+    detail,
+    remedy: `${commands}.${update.upgradeNote ? ` ${update.upgradeNote}` : ''}`,
+  }
+}
+
+export async function doctorCommand(json: boolean, update?: UpdateStatus): Promise<number> {
   const checks = await runChecks()
+  const displayedChecks = update === undefined ? checks : [versionCheck(update), ...checks]
   const failed = checks.some((check) => check.status === 'fail')
 
   if (json) {
     // Only JSON on stdout, so the output can be piped into a parser.
-    process.stdout.write(`${JSON.stringify({ ok: !failed, checks }, null, 2)}\n`)
+    process.stdout.write(`${JSON.stringify({
+      ok: !failed,
+      ...(update === undefined ? {} : { update }),
+      checks: displayedChecks,
+    }, null, 2)}\n`)
     return failed ? 1 : 0
   }
 
   const symbol: Record<Status, string> = { ok: '✓', warn: '!', fail: '✗' }
-  for (const check of checks) {
+  for (const check of displayedChecks) {
     process.stdout.write(`${symbol[check.status]} ${check.name.padEnd(15)} ${check.detail}\n`)
     if (check.status !== 'ok' && check.remedy) {
       process.stdout.write(`  ↳ ${check.remedy}\n`)

--- a/server/cli/launcher.cjs
+++ b/server/cli/launcher.cjs
@@ -38,7 +38,11 @@ if (!isSupported(process.versions.node)) {
 
 // Only reached on a supported runtime, so the real CLI is free to use modern
 // syntax and ES modules.
-import('./cli.js').catch(function (error) {
+import('./cli.js').then(function (cli) {
+  return cli.main(process.argv.slice(2))
+}).then(function (code) {
+  process.exitCode = code
+}).catch(function (error) {
   process.stderr.write('LoopTroop failed to start: ' + (error && error.message ? error.message : error) + '\n')
-  process.exit(1)
+  process.exitCode = 1
 })

--- a/server/lib/installChannel.ts
+++ b/server/lib/installChannel.ts
@@ -20,6 +20,10 @@ export interface InstallInfo {
    * printed on two lines are correct everywhere.
    */
   upgradeFirst?: string
+  /** Run after upgrading so a background daemon loads the new files. */
+  postUpgradeCommand?: string
+  /** Channel-specific context that cannot be expressed as one safe command. */
+  upgradeNote?: string
 }
 
 /**
@@ -31,6 +35,31 @@ export interface InstallInfo {
  */
 const UPGRADE_PREREQUISITES: Partial<Record<InstallChannel, string>> = {
   winget: 'looptroop stop',
+}
+
+const POST_UPGRADE_COMMANDS: Partial<Record<InstallChannel, string>> = {
+  npm: 'looptroop restart',
+  bun: 'looptroop restart',
+  pnpm: 'looptroop restart',
+  yarn: 'looptroop restart',
+  homebrew: 'looptroop restart',
+  scoop: 'looptroop restart',
+  chocolatey: 'looptroop restart',
+  winget: 'looptroop open',
+  aur: 'looptroop restart',
+  source: 'looptroop restart',
+}
+
+const UPGRADE_NOTES: Partial<Record<InstallChannel, string>> = {
+  pnpm: 'pnpm may hold a newly published version for about 24 hours; retry later or install the exact version shown.',
+  homebrew: 'If Homebrew has not indexed this release yet, retry after the channel publish finishes.',
+  scoop: 'If Scoop has not indexed this release yet, retry after the channel publish finishes.',
+  chocolatey: 'Chocolatey releases can remain unavailable while community moderation is pending.',
+  winget: 'WinGet releases can lag GitHub while the manifest is reviewed and indexed.',
+  aur: 'AUR releases can lag GitHub until the package update is published.',
+  binary: 'The standalone installer stops and restarts a running LoopTroop daemon automatically.',
+  container: 'The image tag can briefly lag the GitHub release. After pulling it, recreate the LoopTroop container with the same volumes, ports, and environment settings.',
+  unknown: 'Restart a running LoopTroop daemon after upgrading so it loads the new version.',
 }
 
 const UPGRADE_COMMANDS: Record<InstallChannel, string> = {
@@ -230,8 +259,7 @@ export function detectInstallChannel(moduleDir = dirname(fileURLToPath(import.me
 
 export function getInstallInfo(moduleDir?: string): InstallInfo {
   const channel = detectInstallChannel(moduleDir)
-  const first = UPGRADE_PREREQUISITES[channel]
-  return { channel, upgradeCommand: UPGRADE_COMMANDS[channel], ...(first === undefined ? {} : { upgradeFirst: first }) }
+  return info(channel)
 }
 
 /** The `install` object in `config.json`. */
@@ -273,7 +301,15 @@ export interface ResolveInstallOptions {
 
 function info(channel: InstallChannel): InstallInfo {
   const first = UPGRADE_PREREQUISITES[channel]
-  return { channel, upgradeCommand: UPGRADE_COMMANDS[channel], ...(first === undefined ? {} : { upgradeFirst: first }) }
+  const post = POST_UPGRADE_COMMANDS[channel]
+  const note = UPGRADE_NOTES[channel]
+  return {
+    channel,
+    upgradeCommand: UPGRADE_COMMANDS[channel],
+    ...(first === undefined ? {} : { upgradeFirst: first }),
+    ...(post === undefined ? {} : { postUpgradeCommand: post }),
+    ...(note === undefined ? {} : { upgradeNote: note }),
+  }
 }
 
 function record(channel: InstallChannel, moduleDir: string, configDir?: string): void {

--- a/server/lib/updateCheck.ts
+++ b/server/lib/updateCheck.ts
@@ -39,6 +39,33 @@ export interface UpdateStatus {
   release: ReleaseDetails | null
 }
 
+/** A release without its body. See `summarizeUpdateStatus`. */
+export type ReleaseSummary = Omit<ReleaseDetails, 'notes'>
+
+export interface UpdateStatusSummary extends Omit<UpdateStatus, 'release'> {
+  release: ReleaseSummary | null
+}
+
+/**
+ * Drops the release body, which is several kilobytes of prose.
+ *
+ * The interface renders those notes, so `/api/health/update` keeps them. A CLI
+ * `--json` document is read by scripts that want the facts, and burying them
+ * under a changelog helps nobody.
+ */
+export function summarizeUpdateStatus(status: UpdateStatus): UpdateStatusSummary {
+  const { release, ...rest } = status
+  return {
+    ...rest,
+    release: release === null ? null : {
+      version: release.version,
+      name: release.name,
+      url: release.url,
+      publishedAt: release.publishedAt,
+    },
+  }
+}
+
 export interface UpdateNotice {
   currentVersion: string
   latestVersion: string

--- a/server/lib/updateCheck.ts
+++ b/server/lib/updateCheck.ts
@@ -2,46 +2,67 @@ import { readFileSync } from 'node:fs'
 import { resolve } from 'node:path'
 import { resolveAppConfigDir, ensureSecureDir, secureFile } from './appConfigDir'
 import { safeAtomicWrite } from '../io/atomicWrite'
-import { resolveInstallInfo, isNewerVersion } from './installChannel'
+import { resolveInstallInfo, isNewerVersion, type InstallChannel } from './installChannel'
 
-const REGISTRY_URL = 'https://registry.npmjs.org/looptroop/latest'
+const LATEST_RELEASE_URL = 'https://api.github.com/repos/looptroop-ai/LoopTroop/releases/latest'
 
-/** One check a day: an update notice is not worth a request on every command. */
-export const CHECK_INTERVAL_MS = 24 * 60 * 60 * 1000
+/** Refresh often enough for release-day discovery without taxing GitHub on every command. */
+export const CHECK_INTERVAL_MS = 15 * 60 * 1000
 
 const REQUEST_TIMEOUT_MS = 3_000
 
+export interface ReleaseDetails {
+  version: string
+  name: string
+  url: string
+  publishedAt: string | null
+  notes: string
+}
+
 interface UpdateCache {
-  /**
-   * When a lookup was last attempted, whether or not it answered.
-   *
-   * Separate from `lastCheckedAt`, which is when a version was last learned: an
-   * offline machine has attempts and no answers, and it is the attempts that
-   * have to be rationed.
-   */
   lastAttemptAt: string
-  /** When `latestVersion` was learned. Absent until a lookup has answered. */
   lastCheckedAt?: string
-  /** The newest version the registry has reported so far. */
   latestVersion?: string
+  release?: ReleaseDetails
+}
+
+export interface UpdateStatus {
+  currentVersion: string
+  latestVersion: string | null
+  updateAvailable: boolean
+  checkedAt: string | null
+  installChannel: InstallChannel
+  upgradeCommand: string
+  upgradeFirst?: string
+  postUpgradeCommand?: string
+  upgradeNote?: string
+  release: ReleaseDetails | null
 }
 
 export interface UpdateNotice {
   currentVersion: string
   latestVersion: string
   upgradeCommand: string
-  /** Run before `upgradeCommand`, where the channel needs it. */
   upgradeFirst?: string
+  postUpgradeCommand?: string
+  upgradeNote?: string
 }
 
 function getCachePath(configDir = resolveAppConfigDir()): string {
   return resolve(configDir, 'update-check.json')
 }
 
-/**
- * Tolerates a cache written before failures were recorded, where the only
- * timestamp was the one on a successful answer.
- */
+function isReleaseDetails(value: unknown): value is ReleaseDetails {
+  if (typeof value !== 'object' || value === null) return false
+  const candidate = value as Partial<ReleaseDetails>
+  return typeof candidate.version === 'string'
+    && typeof candidate.name === 'string'
+    && typeof candidate.url === 'string'
+    && (candidate.publishedAt === null || typeof candidate.publishedAt === 'string')
+    && typeof candidate.notes === 'string'
+}
+
+/** Tolerates cache files written by the older npm-version-only checker. */
 function readCache(configDir?: string): UpdateCache | null {
   try {
     const parsed: unknown = JSON.parse(readFileSync(getCachePath(configDir), 'utf8'))
@@ -56,6 +77,7 @@ function readCache(configDir?: string): UpdateCache | null {
       lastAttemptAt,
       ...(lastCheckedAt === undefined ? {} : { lastCheckedAt }),
       ...(typeof candidate.latestVersion === 'string' ? { latestVersion: candidate.latestVersion } : {}),
+      ...(isReleaseDetails(candidate.release) ? { release: candidate.release } : {}),
     }
   } catch {
     return null
@@ -76,68 +98,102 @@ function writeCache(cache: UpdateCache, configDir?: string): void {
 export interface CheckForUpdateOptions {
   currentVersion: string
   configDir?: string
-  /** Injected by tests so no network request is made. */
+  /** Version-only injection retained for focused tests and offline callers. */
   fetchLatest?: () => Promise<string | null>
+  /** Full release injection used by tests that exercise changelog metadata. */
+  fetchRelease?: () => Promise<ReleaseDetails | null>
   now?: () => number
 }
 
-async function fetchLatestFromRegistry(): Promise<string | null> {
+async function fetchLatestRelease(): Promise<ReleaseDetails | null> {
   try {
-    const response = await fetch(REGISTRY_URL, { signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS) })
+    const response = await fetch(LATEST_RELEASE_URL, {
+      headers: {
+        Accept: 'application/vnd.github+json',
+        'User-Agent': 'LoopTroop-update-check',
+        'X-GitHub-Api-Version': '2022-11-28',
+      },
+      signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+    })
     if (!response.ok) return null
-    const body = await response.json() as { version?: unknown }
-    return typeof body.version === 'string' ? body.version : null
+    const body = await response.json() as Record<string, unknown>
+    if (typeof body.tag_name !== 'string' || typeof body.html_url !== 'string') return null
+    const version = body.tag_name.replace(/^v/, '')
+    return {
+      version,
+      name: typeof body.name === 'string' && body.name ? body.name : `LoopTroop ${version}`,
+      url: body.html_url,
+      publishedAt: typeof body.published_at === 'string' ? body.published_at : null,
+      notes: typeof body.body === 'string' ? body.body : '',
+    }
   } catch {
     return null
   }
 }
 
-/**
- * Returns a notice only when a newer version exists.
- *
- * Notify-only by design: LoopTroop never updates itself, because a tool that
- * rewrites its own binary while orchestrating someone's repository is a much
- * worse failure than being one version behind.
- */
-export async function checkForUpdate(options: CheckForUpdateOptions): Promise<UpdateNotice | null> {
+export async function getUpdateStatus(options: CheckForUpdateOptions): Promise<UpdateStatus> {
   const now = options.now?.() ?? Date.now()
   const cached = readCache(options.configDir)
-
   let latestVersion = cached?.latestVersion ?? null
+  let release = cached?.release ?? null
+  let checkedAt = cached?.lastCheckedAt ?? null
   const lastAttempt = cached ? Date.parse(cached.lastAttemptAt) : Number.NaN
   const isStale = !Number.isFinite(lastAttempt) || now - lastAttempt > CHECK_INTERVAL_MS
 
   if (isStale) {
     const attemptedAt = new Date(now).toISOString()
-    const fetched = await (options.fetchLatest ?? fetchLatestFromRegistry)()
+    const fetchedRelease = options.fetchRelease
+      ? await options.fetchRelease()
+      : options.fetchLatest
+        ? await options.fetchLatest().then((version) => version === null ? null : {
+            version,
+            name: `LoopTroop ${version}`,
+            url: `https://github.com/looptroop-ai/LoopTroop/releases/tag/v${version}`,
+            publishedAt: null,
+            notes: '',
+          })
+        : await fetchLatestRelease()
 
-    if (fetched) latestVersion = fetched
+    if (fetchedRelease) {
+      release = fetchedRelease
+      latestVersion = fetchedRelease.version
+      checkedAt = attemptedAt
+    }
 
-    // The attempt is recorded either way. Recording only answers meant a machine
-    // that cannot reach the registry — offline, or behind a proxy that swallows
-    // the request — never had a fresh timestamp to compare against, so every
-    // single command paid the full request timeout again. A failed lookup still
-    // keeps whatever the last answer was, rather than nagging or forgetting.
     writeCache({
       lastAttemptAt: attemptedAt,
-      ...(fetched
-        ? { lastCheckedAt: attemptedAt, latestVersion: fetched }
-        : {
-            ...(cached?.lastCheckedAt === undefined ? {} : { lastCheckedAt: cached.lastCheckedAt }),
-            ...(latestVersion === null ? {} : { latestVersion }),
-          }),
+      ...(checkedAt === null ? {} : { lastCheckedAt: checkedAt }),
+      ...(latestVersion === null ? {} : { latestVersion }),
+      ...(release === null ? {} : { release }),
     }, options.configDir)
   }
 
-  if (!latestVersion || !isNewerVersion(latestVersion, options.currentVersion)) return null
-
+  const install = resolveInstallInfo({ ...(options.configDir ? { configDir: options.configDir } : {}) })
   return {
     currentVersion: options.currentVersion,
     latestVersion,
-    ...(() => {
-      const info = resolveInstallInfo({ ...(options.configDir ? { configDir: options.configDir } : {}) })
-      return { upgradeCommand: info.upgradeCommand, ...(info.upgradeFirst === undefined ? {} : { upgradeFirst: info.upgradeFirst }) }
-    })(),
+    updateAvailable: latestVersion !== null && isNewerVersion(latestVersion, options.currentVersion),
+    checkedAt,
+    installChannel: install.channel,
+    upgradeCommand: install.upgradeCommand,
+    ...(install.upgradeFirst === undefined ? {} : { upgradeFirst: install.upgradeFirst }),
+    ...(install.postUpgradeCommand === undefined ? {} : { postUpgradeCommand: install.postUpgradeCommand }),
+    ...(install.upgradeNote === undefined ? {} : { upgradeNote: install.upgradeNote }),
+    release,
+  }
+}
+
+/** Returns a notice only when a newer published GitHub release exists. */
+export async function checkForUpdate(options: CheckForUpdateOptions): Promise<UpdateNotice | null> {
+  const status = await getUpdateStatus(options)
+  if (!status.updateAvailable || status.latestVersion === null) return null
+  return {
+    currentVersion: status.currentVersion,
+    latestVersion: status.latestVersion,
+    upgradeCommand: status.upgradeCommand,
+    ...(status.upgradeFirst === undefined ? {} : { upgradeFirst: status.upgradeFirst }),
+    ...(status.postUpgradeCommand === undefined ? {} : { postUpgradeCommand: status.postUpgradeCommand }),
+    ...(status.upgradeNote === undefined ? {} : { upgradeNote: status.upgradeNote }),
   }
 }
 
@@ -145,10 +201,15 @@ export function formatUpdateNotice(notice: UpdateNotice): string {
   return [
     '',
     `LoopTroop ${notice.latestVersion} is available (you have ${notice.currentVersion}).`,
-    // One command per line, each valid on its own. Joining them would need an
-    // operator, and none works in both `cmd.exe` and Windows PowerShell 5.1.
     ...(notice.upgradeFirst === undefined ? [] : [`  ${notice.upgradeFirst}`]),
     `  ${notice.upgradeCommand}`,
+    ...(notice.postUpgradeCommand === undefined ? [] : [`  ${notice.postUpgradeCommand}`]),
+    ...(notice.upgradeNote === undefined ? [] : [`  ${notice.upgradeNote}`]),
     '',
   ].join('\n')
+}
+
+export function formatUpdateStatusNotice(status: UpdateStatus): string {
+  if (!status.updateAvailable || status.latestVersion === null) return ''
+  return formatUpdateNotice(status as UpdateNotice & { latestVersion: string })
 }

--- a/server/routes/__tests__/health.test.ts
+++ b/server/routes/__tests__/health.test.ts
@@ -1,11 +1,12 @@
 import { Database } from '../../db/sqliteShim'
 import { afterAll, afterEach, describe, expect, it, vi } from 'vitest'
-import { mkdirSync, mkdtempSync, rmSync } from 'node:fs'
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { dirname, join } from 'node:path'
 import { Hono } from 'hono'
 import { createFixtureRepoManager } from '../../test/fixtureRepo'
 import { getProjectDbPath, normalizeFolderPath } from '../../storage/paths'
+import packageJson from '../../../package.json'
 
 const repoManager = createFixtureRepoManager({
   templatePrefix: 'looptroop-health-route-',
@@ -91,6 +92,47 @@ describe('health startup routes', () => {
 
   afterAll(() => {
     repoManager.cleanup()
+  })
+
+  it('reports the current and latest release with installation-aware update steps', async () => {
+    const tempRoot = mkdtempSync(join(tmpdir(), 'looptroop-health-update-'))
+    tempRoots.add(tempRoot)
+    const configDir = join(tempRoot, 'config')
+    mkdirSync(configDir, { recursive: true })
+    const checkedAt = new Date().toISOString()
+    writeFileSync(join(configDir, 'update-check.json'), `${JSON.stringify({
+      lastAttemptAt: checkedAt,
+      lastCheckedAt: checkedAt,
+      latestVersion: '9.0.0',
+      release: {
+        version: '9.0.0',
+        name: 'LoopTroop 9.0.0',
+        url: 'https://github.com/looptroop-ai/LoopTroop/releases/tag/v9.0.0',
+        publishedAt: checkedAt,
+        notes: 'A future test release.',
+      },
+    }, null, 2)}\n`)
+
+    activeApp = await loadHealthApp(configDir)
+    const response = await activeApp.app.request('/api/health/update')
+    expect(response.status).toBe(200)
+    const payload = await response.json() as {
+      currentVersion: string
+      latestVersion: string
+      updateAvailable: boolean
+      installChannel: string
+      upgradeCommand: string
+      postUpgradeCommand?: string
+      release: { notes: string }
+    }
+
+    expect(payload.currentVersion).toBe(packageJson.version)
+    expect(payload.latestVersion).toBe('9.0.0')
+    expect(payload.updateAvailable).toBe(true)
+    expect(payload.installChannel).toBe('source')
+    expect(payload.upgradeCommand).toBe('git pull && npm install && npm run build')
+    expect(payload.postUpgradeCommand).toBe('looptroop restart')
+    expect(payload.release.notes).toBe('A future test release.')
   })
 
   it('reports fresh startup state when the app db did not exist before boot', async () => {

--- a/server/routes/health.ts
+++ b/server/routes/health.ts
@@ -1,6 +1,8 @@
 import { Hono } from 'hono'
 import { getOpenCodeAdapter } from '../opencode/factory'
 import { dismissStartupRestoreNotice, getStartupStatus } from '../startupState'
+import { APP_VERSION } from '../lib/appVersion'
+import { getUpdateStatus } from '../lib/updateCheck'
 
 const health = new Hono()
 
@@ -25,6 +27,10 @@ health.get('/health/opencode', async (c) => {
 
 health.get('/health/startup', (c) => {
   return c.json(getStartupStatus())
+})
+
+health.get('/health/update', async (c) => {
+  return c.json(await getUpdateStatus({ currentVersion: APP_VERSION }))
 })
 
 health.post('/health/startup/restore-notice/dismiss', (c) => {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -230,6 +230,7 @@ function App() {
           onOpenPrompts={openPrompts}
           onOpenProject={openProject}
           onOpenTicket={openTicket}
+          onOpenAbout={openAbout}
           isModalOpen={isModalOpen}
         >
           {state.activeView === 'ticket' && state.selectedTicketId ? <TicketDashboard /> : <KanbanBoard />}

--- a/src/components/config/AboutDialog.tsx
+++ b/src/components/config/AboutDialog.tsx
@@ -5,6 +5,7 @@ import { HoverCard, HoverCardContent, HoverCardTrigger } from '@/components/ui/h
 import { useProjects } from '@/hooks/useProjects'
 import { useStartupStatus } from '@/hooks/useStartupStatus'
 import { useUpdateStatus } from '@/hooks/useUpdateStatus'
+import { ReleaseNotes } from './ReleaseNotes'
 
 function formatStorageSource(source: string) {
   if (source === 'LOOPTROOP_APP_DB_PATH') return 'Custom database path override'
@@ -104,8 +105,10 @@ export function AboutDialog() {
                       </p>
                     )}
                   </div>
-                  <div className="max-h-80 overflow-y-auto whitespace-pre-wrap px-4 py-3 text-xs leading-relaxed text-muted-foreground">
-                    {update.release?.notes || 'Open GitHub to view all LoopTroop release notes.'}
+                  <div className="max-h-80 overflow-y-auto px-4 py-3">
+                    {update.release?.notes
+                      ? <ReleaseNotes notes={update.release.notes} />
+                      : <p className="text-xs leading-relaxed text-muted-foreground">Open GitHub to view all LoopTroop release notes.</p>}
                   </div>
                 </HoverCardContent>
               </HoverCard>

--- a/src/components/config/AboutDialog.tsx
+++ b/src/components/config/AboutDialog.tsx
@@ -1,8 +1,10 @@
-import packageJson from '../../../package.json'
-import { AlertTriangle, Database, Settings } from 'lucide-react'
+import { AlertTriangle, CircleArrowUp, Database, ExternalLink, Settings } from 'lucide-react'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Button } from '@/components/ui/button'
+import { HoverCard, HoverCardContent, HoverCardTrigger } from '@/components/ui/hover-card'
 import { useProjects } from '@/hooks/useProjects'
 import { useStartupStatus } from '@/hooks/useStartupStatus'
+import { useUpdateStatus } from '@/hooks/useUpdateStatus'
 
 function formatStorageSource(source: string) {
   if (source === 'LOOPTROOP_APP_DB_PATH') return 'Custom database path override'
@@ -13,6 +15,7 @@ function formatStorageSource(source: string) {
 export function AboutDialog() {
   const { data: startupStatus } = useStartupStatus()
   const { data: projects } = useProjects()
+  const { data: update, isLoading: isUpdateLoading } = useUpdateStatus()
 
   if (!startupStatus) {
     return (
@@ -25,12 +28,91 @@ export function AboutDialog() {
   }
 
   const attachedProjectCount = projects?.length ?? startupStatus.storage.restoredProjectCount
+  const releaseUrl = update?.release?.url ?? 'https://github.com/looptroop-ai/LoopTroop/releases'
+  const updateCommands = update
+    ? [update.upgradeFirst, update.upgradeCommand, update.postUpgradeCommand].filter((command): command is string => command !== undefined)
+    : []
 
   return (
     <div className="space-y-5">
       <div className="rounded-xl border border-border/60 bg-muted/30 p-3.5 text-sm text-muted-foreground leading-relaxed">
         LoopTroop stores application data centrally and keeps project-specific state inside each attached repository.
       </div>
+
+      <Card className="rounded-xl border border-border/70 bg-card shadow-2xs">
+        <CardHeader className="pb-3">
+          <CardTitle className="flex items-center gap-2.5 text-base font-semibold text-foreground">
+            <div className="flex h-7 w-7 items-center justify-center rounded-lg border border-border/70 bg-muted text-muted-foreground">
+              <CircleArrowUp className="h-4 w-4" />
+            </div>
+            Updates
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          {isUpdateLoading && <p className="text-sm text-muted-foreground animate-pulse">Checking the latest published release…</p>}
+          {update && (
+            <>
+              <div className="grid gap-3 sm:grid-cols-2">
+                <div>
+                  <p className="text-xs font-semibold uppercase tracking-wider text-muted-foreground/90 font-mono">Current Version</p>
+                  <p className="mt-1 font-mono text-sm font-semibold text-foreground">v{update.currentVersion}</p>
+                </div>
+                <div>
+                  <p className="text-xs font-semibold uppercase tracking-wider text-muted-foreground/90 font-mono">Latest Version</p>
+                  <p className="mt-1 font-mono text-sm font-semibold text-foreground">{update.latestVersion ? `v${update.latestVersion}` : 'Unavailable'}</p>
+                </div>
+              </div>
+
+              <p className="text-sm text-muted-foreground">
+                {update.updateAvailable
+                  ? `A newer version is available for this ${update.installChannel} installation.`
+                  : update.latestVersion
+                    ? 'You are running the latest published version.'
+                    : 'The latest release could not be checked. Cached information will be used when available.'}
+              </p>
+
+              {update.updateAvailable && (
+                <div className="rounded-lg border border-border/70 bg-muted/35 p-3">
+                  <p className="mb-2 text-xs font-semibold uppercase tracking-wider text-muted-foreground font-mono">How to update</p>
+                  <ol className="space-y-2">
+                    {updateCommands.map((command, index) => (
+                      <li key={command} className="flex gap-2 text-xs">
+                        <span className="mt-1 text-muted-foreground">{index + 1}.</span>
+                        <code className="min-w-0 break-all rounded border border-border/60 bg-background px-2 py-1 font-mono text-foreground">{command}</code>
+                      </li>
+                    ))}
+                  </ol>
+                  {update.upgradeNote && <p className="mt-2 text-xs leading-relaxed text-muted-foreground">{update.upgradeNote}</p>}
+                </div>
+              )}
+
+              <HoverCard openDelay={250} closeDelay={150}>
+                <HoverCardTrigger asChild>
+                  <Button variant="outline" size="sm" asChild>
+                    <a href={releaseUrl} target="_blank" rel="noreferrer noopener">
+                      Changelog
+                      <ExternalLink className="ml-1.5 h-3.5 w-3.5" />
+                    </a>
+                  </Button>
+                </HoverCardTrigger>
+                <HoverCardContent align="start" className="w-[min(34rem,calc(100vw-2rem))] p-0">
+                  <div className="border-b border-border/70 px-4 py-3">
+                    <p className="font-semibold text-sm">{update.release?.name ?? 'LoopTroop releases'}</p>
+                    {update.release?.publishedAt && (
+                      <p className="mt-0.5 text-xs text-muted-foreground">
+                        Published {new Date(update.release.publishedAt).toLocaleDateString()}
+                      </p>
+                    )}
+                  </div>
+                  <div className="max-h-80 overflow-y-auto whitespace-pre-wrap px-4 py-3 text-xs leading-relaxed text-muted-foreground">
+                    {update.release?.notes || 'Open GitHub to view all LoopTroop release notes.'}
+                  </div>
+                </HoverCardContent>
+              </HoverCard>
+            </>
+          )}
+        </CardContent>
+      </Card>
 
       <Card className="rounded-xl border border-border/70 bg-card shadow-2xs hover:border-brand-500/30 transition-all">
         <CardHeader className="pb-3">
@@ -42,15 +124,7 @@ export function AboutDialog() {
           </CardTitle>
         </CardHeader>
         <CardContent className="grid gap-4 sm:grid-cols-2">
-          <div>
-            <p className="text-xs font-semibold uppercase tracking-wider text-muted-foreground/90 font-mono">Version</p>
-            <div className="mt-1 flex items-center gap-2">
-              <span className="inline-flex items-center gap-1.5 px-2.5 py-0.5 rounded-full bg-brand-500/10 text-brand-700 dark:text-brand-300 font-mono text-xs font-semibold border border-brand-500/30 shadow-2xs">
-                v{packageJson.version}
-              </span>
-            </div>
-          </div>
-          <div>
+          <div className="sm:col-span-2">
             <p className="text-xs font-semibold uppercase tracking-wider text-muted-foreground/90 font-mono">Operating System</p>
             <p className="mt-1 text-sm font-medium text-foreground">{startupStatus.runtime.osLabel}</p>
           </div>

--- a/src/components/config/ReleaseNotes.tsx
+++ b/src/components/config/ReleaseNotes.tsx
@@ -1,0 +1,142 @@
+import type { ReactNode } from 'react'
+
+/**
+ * Renders the subset of Markdown that GitHub release bodies for this project
+ * actually contain: headings, bullet lists, fenced code, bold, inline code and
+ * links.
+ *
+ * Deliberately not a Markdown library. The notes are generated from
+ * `CHANGELOG.md` by `scripts/print-release-notes.ts`, so their shape is known
+ * and narrow, and a renderer for it costs less than a dependency in every
+ * bundle and every install channel. Anything unrecognised falls through as
+ * plain text rather than being dropped.
+ */
+
+/** Built per call: a shared `g` regex carries `lastIndex` between callers. */
+const inlinePattern = () => /(`[^`]+`)|(\*\*[^*]+\*\*)|(\[[^\]]+\]\([^)]+\))/g
+
+/** Only http(s) becomes a link; anything else renders as its own text. */
+function safeHref(url: string): string | null {
+  try {
+    const parsed = new URL(url)
+    return parsed.protocol === 'https:' || parsed.protocol === 'http:' ? parsed.href : null
+  } catch {
+    return null
+  }
+}
+
+function renderInline(text: string, keyPrefix: string): ReactNode[] {
+  const nodes: ReactNode[] = []
+  const pattern = inlinePattern()
+  let lastIndex = 0
+  let match: RegExpExecArray | null
+
+  while ((match = pattern.exec(text)) !== null) {
+    if (match.index > lastIndex) nodes.push(text.slice(lastIndex, match.index))
+    const token = match[0]
+    const key = `${keyPrefix}-${String(match.index)}`
+
+    if (token.startsWith('`')) {
+      nodes.push(
+        <code key={key} className="rounded border border-border/60 bg-background px-1 py-0.5 font-mono text-[11px] text-foreground">
+          {token.slice(1, -1)}
+        </code>,
+      )
+    } else if (token.startsWith('**')) {
+      nodes.push(<strong key={key} className="font-semibold text-foreground">{token.slice(2, -2)}</strong>)
+    } else {
+      const split = token.indexOf('](')
+      const label = token.slice(1, split)
+      const href = safeHref(token.slice(split + 2, -1))
+      nodes.push(href === null
+        ? label
+        : <a key={key} href={href} target="_blank" rel="noreferrer noopener" className="text-brand-600 underline underline-offset-2 dark:text-brand-400">{label}</a>)
+    }
+    lastIndex = match.index + token.length
+  }
+
+  if (lastIndex < text.length) nodes.push(text.slice(lastIndex))
+  return nodes
+}
+
+export function ReleaseNotes({ notes }: { notes: string }) {
+  const blocks: ReactNode[] = []
+  // Release bodies carry `<!-- container:start -->` markers around the generated
+  // image section. They are structure for the release tooling, not content.
+  const lines = notes.replace(/<!--[\s\S]*?-->/g, '').split(/\r?\n/)
+
+  let bullets: string[] = []
+  let code: string[] | null = null
+
+  const flushBullets = () => {
+    if (bullets.length === 0) return
+    const items = bullets
+    blocks.push(
+      <ul key={`ul-${String(blocks.length)}`} className="ml-4 list-disc space-y-1.5 marker:text-muted-foreground/60">
+        {items.map((item, index) => (
+          <li key={item.slice(0, 60) + String(index)}>{renderInline(item, `li-${String(index)}`)}</li>
+        ))}
+      </ul>,
+    )
+    bullets = []
+  }
+
+  for (const line of lines) {
+    if (line.trimStart().startsWith('```')) {
+      if (code === null) {
+        flushBullets()
+        code = []
+      } else {
+        blocks.push(
+          <pre key={`pre-${String(blocks.length)}`} className="overflow-x-auto rounded-md border border-border/60 bg-background p-2.5 font-mono text-[11px] text-foreground">
+            <code>{code.join('\n')}</code>
+          </pre>,
+        )
+        code = null
+      }
+      continue
+    }
+    if (code !== null) {
+      code.push(line)
+      continue
+    }
+
+    const heading = /^(#{1,6})\s+(.*)$/.exec(line)
+    if (heading) {
+      flushBullets()
+      blocks.push(
+        <p key={`h-${String(blocks.length)}`} className="mt-1 text-xs font-semibold uppercase tracking-wider text-foreground">
+          {renderInline(heading[2] ?? '', `h-${String(blocks.length)}`)}
+        </p>,
+      )
+      continue
+    }
+
+    const bullet = /^\s*[-*]\s+(.*)$/.exec(line)
+    if (bullet) {
+      bullets.push(bullet[1] ?? '')
+      continue
+    }
+
+    if (line.trim() === '') {
+      flushBullets()
+      continue
+    }
+
+    flushBullets()
+    blocks.push(<p key={`p-${String(blocks.length)}`}>{renderInline(line, `p-${String(blocks.length)}`)}</p>)
+  }
+
+  flushBullets()
+  // An unterminated fence still shows its content rather than swallowing it.
+  if (code !== null && code.length > 0) {
+    blocks.push(
+      <pre key={`pre-${String(blocks.length)}`} className="overflow-x-auto rounded-md border border-border/60 bg-background p-2.5 font-mono text-[11px] text-foreground">
+        <code>{code.join('\n')}</code>
+      </pre>,
+    )
+  }
+
+  // Every block carries its own key, so no wrapper is needed here.
+  return <div className="space-y-2.5 text-xs leading-relaxed text-muted-foreground">{blocks}</div>
+}

--- a/src/components/config/__tests__/AboutDialog.test.tsx
+++ b/src/components/config/__tests__/AboutDialog.test.tsx
@@ -1,6 +1,7 @@
-import { render, screen } from '@testing-library/react'
+import { fireEvent, render, screen } from '@testing-library/react'
 import { describe, expect, it, vi } from 'vitest'
 import { AboutDialog } from '../AboutDialog'
+import packageJson from '../../../../package.json'
 
 vi.mock('@/hooks/useStartupStatus', () => ({
   useStartupStatus: () => ({
@@ -39,6 +40,28 @@ vi.mock('@/hooks/useProjects', () => ({
   }),
 }))
 
+vi.mock('@/hooks/useUpdateStatus', () => ({
+  useUpdateStatus: () => ({
+    isLoading: false,
+    data: {
+      currentVersion: packageJson.version,
+      latestVersion: '0.6.0',
+      updateAvailable: true,
+      checkedAt: '2026-08-16T08:00:00.000Z',
+      installChannel: 'npm',
+      upgradeCommand: 'npm install -g looptroop@latest',
+      postUpgradeCommand: 'looptroop restart',
+      release: {
+        version: '0.6.0',
+        name: 'LoopTroop 0.6.0',
+        url: 'https://github.com/looptroop-ai/LoopTroop/releases/tag/v0.6.0',
+        publishedAt: '2026-08-15T12:00:00.000Z',
+        notes: 'Added release-aware update guidance.\n\nFixed stale daemon instructions.',
+      },
+    },
+  }),
+}))
+
 describe('AboutDialog', () => {
   it('renders runtime and storage details with the professional labels', () => {
     render(<AboutDialog />)
@@ -51,5 +74,20 @@ describe('AboutDialog', () => {
     expect(screen.getByText('/home/liviu/.config/looptroop')).toBeInTheDocument()
     expect(screen.getByText('2')).toBeInTheDocument()
     expect(screen.getByText('<repo>/.looptroop/')).toBeInTheDocument()
+  })
+
+  it('shows the available version, exact update steps, and release details', async () => {
+    render(<AboutDialog />)
+
+    expect(screen.getByText(`v${packageJson.version}`)).toBeInTheDocument()
+    expect(screen.getByText('v0.6.0')).toBeInTheDocument()
+    expect(screen.getByText('npm install -g looptroop@latest')).toBeInTheDocument()
+    expect(screen.getByText('looptroop restart')).toBeInTheDocument()
+
+    const changelog = screen.getByRole('link', { name: /changelog/i })
+    expect(changelog).toHaveAttribute('href', 'https://github.com/looptroop-ai/LoopTroop/releases/tag/v0.6.0')
+    fireEvent.focus(changelog)
+
+    expect(await screen.findByText(/Added release-aware update guidance/)).toBeInTheDocument()
   })
 })

--- a/src/components/config/__tests__/ReleaseNotes.test.tsx
+++ b/src/components/config/__tests__/ReleaseNotes.test.tsx
@@ -6,6 +6,9 @@ import { ReleaseNotes } from '../ReleaseNotes'
  * Shaped after a real release body produced by `scripts/print-release-notes.ts`
  * — bullets carrying bold and inline code, a heading, a fenced block, a link,
  * and the HTML comment markers the container section is wrapped in.
+ *
+ * The tag is deliberately an impossible version: `verify:version` fails on the
+ * real one appearing anywhere outside `package.json`, fixtures included.
  */
 const NOTES = [
   '- **Starting LoopTroop is one command.** `looptroop open` now starts the daemon.',
@@ -15,7 +18,7 @@ const NOTES = [
   '### Container image',
   '',
   '```',
-  'docker pull looptroopai/looptroop:0.5.5',
+  'docker pull looptroopai/looptroop:9.9.9',
   '```',
   '',
   'See [Run it in a container](https://github.com/looptroop-ai/LoopTroop#run-it-in-a-container) for how.',
@@ -30,7 +33,7 @@ describe('ReleaseNotes', () => {
     expect(screen.getByText('Starting LoopTroop is one command.').tagName).toBe('STRONG')
     expect(screen.getByText('looptroop open').tagName).toBe('CODE')
     expect(screen.getByText('Container image')).toBeInTheDocument()
-    expect(screen.getByText('docker pull looptroopai/looptroop:0.5.5').tagName).toBe('CODE')
+    expect(screen.getByText('docker pull looptroopai/looptroop:9.9.9').tagName).toBe('CODE')
 
     const link = screen.getByRole('link', { name: 'Run it in a container' })
     expect(link).toHaveAttribute('href', 'https://github.com/looptroop-ai/LoopTroop#run-it-in-a-container')

--- a/src/components/config/__tests__/ReleaseNotes.test.tsx
+++ b/src/components/config/__tests__/ReleaseNotes.test.tsx
@@ -1,0 +1,60 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import { ReleaseNotes } from '../ReleaseNotes'
+
+/**
+ * Shaped after a real release body produced by `scripts/print-release-notes.ts`
+ * — bullets carrying bold and inline code, a heading, a fenced block, a link,
+ * and the HTML comment markers the container section is wrapped in.
+ */
+const NOTES = [
+  '- **Starting LoopTroop is one command.** `looptroop open` now starts the daemon.',
+  '- An emergency release path that would have produced nothing is fixed.',
+  '',
+  '<!-- container:start -->',
+  '### Container image',
+  '',
+  '```',
+  'docker pull looptroopai/looptroop:0.5.5',
+  '```',
+  '',
+  'See [Run it in a container](https://github.com/looptroop-ai/LoopTroop#run-it-in-a-container) for how.',
+  '<!-- container:end -->',
+].join('\n')
+
+describe('ReleaseNotes', () => {
+  it('renders bullets, bold, inline code, headings, fences and links as markup', () => {
+    render(<ReleaseNotes notes={NOTES} />)
+
+    expect(screen.getAllByRole('listitem')).toHaveLength(2)
+    expect(screen.getByText('Starting LoopTroop is one command.').tagName).toBe('STRONG')
+    expect(screen.getByText('looptroop open').tagName).toBe('CODE')
+    expect(screen.getByText('Container image')).toBeInTheDocument()
+    expect(screen.getByText('docker pull looptroopai/looptroop:0.5.5').tagName).toBe('CODE')
+
+    const link = screen.getByRole('link', { name: 'Run it in a container' })
+    expect(link).toHaveAttribute('href', 'https://github.com/looptroop-ai/LoopTroop#run-it-in-a-container')
+    expect(link).toHaveAttribute('rel', 'noreferrer noopener')
+  })
+
+  it('leaves the comment markers out of the rendered text', () => {
+    const { container } = render(<ReleaseNotes notes={NOTES} />)
+
+    expect(container.textContent).not.toContain('container:start')
+    expect(container.textContent).not.toContain('<!--')
+  })
+
+  /** Release bodies are third-party text; a `javascript:` URL must not become a link. */
+  it('renders a non-http link target as plain text', () => {
+    render(<ReleaseNotes notes={'See [the notes](javascript:alert(1)) here.'} />)
+
+    expect(screen.queryByRole('link')).toBeNull()
+    expect(screen.getByText(/the notes/)).toBeInTheDocument()
+  })
+
+  it('shows the content of an unterminated fence rather than swallowing it', () => {
+    render(<ReleaseNotes notes={'```\nnpm install -g looptroop'} />)
+
+    expect(screen.getByText('npm install -g looptroop')).toBeInTheDocument()
+  })
+})

--- a/src/components/layout/AppShell.tsx
+++ b/src/components/layout/AppShell.tsx
@@ -78,6 +78,12 @@ export function AppShell({ children, onOpenProfile, onOpenPrompts, onOpenProject
   const docsOrigin = `${__LOOPTROOP_DOCS_ORIGIN__}/`
   const { isOffline } = useBackendHealth()
   const { data: update } = useUpdateStatus()
+  /**
+   * The daemon's own version wins over the one bundled into this build. They
+   * agree for a normal install, but a browser tab left open across an upgrade
+   * would otherwise keep showing the version it was served with.
+   */
+  const version = update?.currentVersion ?? packageJson.version
   const activeTriageFilterSummaries = getActiveTriageFilterSummaries(state.filters)
   const activeTriageFilterCount = activeTriageFilterSummaries.length
 
@@ -110,13 +116,12 @@ export function AppShell({ children, onOpenProfile, onOpenPrompts, onOpenProject
               <button
                 type="button"
                 onClick={onOpenAbout}
-                disabled={isModalOpen}
                 aria-label={update?.updateAvailable
-                  ? `LoopTroop version ${packageJson.version}; update ${update.latestVersion} available; open About`
-                  : `LoopTroop version ${packageJson.version}; open About`}
-                className="hidden items-center gap-1 rounded-full border border-border/60 bg-muted px-1.5 py-0.5 font-mono text-[10px] font-medium text-muted-foreground outline-none transition-opacity hover:opacity-75 focus-visible:ring-2 focus-visible:ring-ring disabled:opacity-50 sm:inline-flex"
+                  ? `LoopTroop version ${version}; update ${update.latestVersion} available; open About`
+                  : `LoopTroop version ${version}; open About`}
+                className="hidden items-center gap-1 rounded-full border border-border/60 bg-muted px-1.5 py-0.5 font-mono text-[10px] font-medium text-muted-foreground outline-none transition-opacity hover:opacity-75 focus-visible:ring-2 focus-visible:ring-ring sm:inline-flex"
               >
-                v{packageJson.version}
+                v{version}
                 {update?.updateAvailable && <CircleArrowUp data-testid="update-available-icon" className="h-3 w-3" aria-hidden="true" />}
               </button>
             </TooltipTrigger>

--- a/src/components/layout/AppShell.tsx
+++ b/src/components/layout/AppShell.tsx
@@ -1,4 +1,4 @@
-import { SunMoon, Moon, Sun, Settings, FolderOpen, Plus, RefreshCw, BookOpen, SlidersHorizontal, MoreHorizontal, MessageSquareText } from 'lucide-react'
+import { SunMoon, Moon, Sun, Settings, FolderOpen, Plus, RefreshCw, BookOpen, SlidersHorizontal, MoreHorizontal, MessageSquareText, CircleArrowUp } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { Tooltip, TooltipTrigger, TooltipContent } from '@/components/ui/tooltip'
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from '@/components/ui/dropdown-menu'
@@ -9,6 +9,7 @@ import { WORKFLOW_GROUPS, WORKFLOW_PHASE_MAP } from '@/lib/workflowMeta'
 import { useQueryClient } from '@tanstack/react-query'
 import { useState } from 'react'
 import { useBackendHealth } from '@/hooks/useBackendHealth'
+import { useUpdateStatus } from '@/hooks/useUpdateStatus'
 import packageJson from '../../../package.json'
 import { DashboardSearch } from './DashboardSearch'
 import { cn } from '@/lib/utils'
@@ -19,6 +20,7 @@ interface AppShellProps {
   onOpenPrompts?: () => void
   onOpenProject?: () => void
   onOpenTicket?: () => void
+  onOpenAbout?: () => void
   isModalOpen?: boolean
 }
 
@@ -68,13 +70,14 @@ function getActiveTriageFilterSummaries(filters: UIState['filters']): string[] {
   return summaries
 }
 
-export function AppShell({ children, onOpenProfile, onOpenPrompts, onOpenProject, onOpenTicket, isModalOpen = false }: AppShellProps) {
+export function AppShell({ children, onOpenProfile, onOpenPrompts, onOpenProject, onOpenTicket, onOpenAbout, isModalOpen = false }: AppShellProps) {
   const { state, dispatch } = useUI()
   const theme = state.theme
   const queryClient = useQueryClient()
   const [isRefreshing, setIsRefreshing] = useState(false)
   const docsOrigin = `${__LOOPTROOP_DOCS_ORIGIN__}/`
   const { isOffline } = useBackendHealth()
+  const { data: update } = useUpdateStatus()
   const activeTriageFilterSummaries = getActiveTriageFilterSummaries(state.filters)
   const activeTriageFilterCount = activeTriageFilterSummaries.length
 
@@ -87,23 +90,41 @@ export function AppShell({ children, onOpenProfile, onOpenPrompts, onOpenProject
   return (
     <div className="min-h-screen bg-background text-foreground antialiased selection:bg-brand-500/20 selection:text-brand-500">
       <header className="sticky top-0 z-50 flex h-14 items-center justify-between border-b border-border/80 bg-background/80 px-2 sm:px-4 md:px-6 backdrop-blur-md supports-[backdrop-filter]:bg-background/60 shadow-xs transition-all">
-        <button
-          className="group flex items-center gap-2.5 cursor-pointer outline-none rounded-lg p-1 -ml-1 transition-all hover:bg-accent/40 focus-visible:ring-2 focus-visible:ring-ring"
-          onClick={() => {
-            dispatch({ type: 'SELECT_TICKET', ticketId: null })
-            window.history.pushState({}, '', '/')
-          }}
-        >
-          <img src="/trans-logo.png" alt="LoopTroop" className="h-7 w-auto transition-transform duration-200 group-hover:scale-105" />
-          <div className="hidden items-baseline gap-2 sm:flex">
-            <span className="text-xl font-bold tracking-tight text-foreground group-hover:text-brand-600 dark:group-hover:text-brand-400 transition-colors">
-              LoopTroop
-            </span>
-            <span className="hidden sm:inline-block text-[10px] font-mono font-medium px-1.5 py-0.5 rounded-full bg-muted text-muted-foreground border border-border/60">
-              v{packageJson.version}
-            </span>
-          </div>
-        </button>
+        <div className="flex items-center gap-1">
+          <button
+            className="group flex items-center gap-2.5 cursor-pointer outline-none rounded-lg p-1 -ml-1 transition-all hover:bg-accent/40 focus-visible:ring-2 focus-visible:ring-ring"
+            onClick={() => {
+              dispatch({ type: 'SELECT_TICKET', ticketId: null })
+              window.history.pushState({}, '', '/')
+            }}
+          >
+            <img src="/trans-logo.png" alt="LoopTroop" className="h-7 w-auto transition-transform duration-200 group-hover:scale-105" />
+            <div className="hidden items-baseline gap-2 sm:flex">
+              <span className="text-xl font-bold tracking-tight text-foreground group-hover:text-brand-600 dark:group-hover:text-brand-400 transition-colors">
+                LoopTroop
+              </span>
+            </div>
+          </button>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <button
+                type="button"
+                onClick={onOpenAbout}
+                disabled={isModalOpen}
+                aria-label={update?.updateAvailable
+                  ? `LoopTroop version ${packageJson.version}; update ${update.latestVersion} available; open About`
+                  : `LoopTroop version ${packageJson.version}; open About`}
+                className="hidden items-center gap-1 rounded-full border border-border/60 bg-muted px-1.5 py-0.5 font-mono text-[10px] font-medium text-muted-foreground outline-none transition-opacity hover:opacity-75 focus-visible:ring-2 focus-visible:ring-ring disabled:opacity-50 sm:inline-flex"
+              >
+                v{packageJson.version}
+                {update?.updateAvailable && <CircleArrowUp data-testid="update-available-icon" className="h-3 w-3" aria-hidden="true" />}
+              </button>
+            </TooltipTrigger>
+            <TooltipContent>
+              {update?.updateAvailable ? `Version ${update.latestVersion} is available. Open About.` : 'Open About'}
+            </TooltipContent>
+          </Tooltip>
+        </div>
         <div className="flex min-w-0 items-center gap-1 sm:gap-2">
           <DashboardSearch isModalOpen={isModalOpen} />
           {state.activeView === 'kanban' && (

--- a/src/components/layout/__tests__/AppShell.test.tsx
+++ b/src/components/layout/__tests__/AppShell.test.tsx
@@ -12,6 +12,7 @@ vi.mock('@/hooks/useBackendHealth', () => ({
 
 const useRecoveryAutoReloadMock = vi.hoisted(() => vi.fn())
 const mockUseProjects = vi.hoisted(() => vi.fn())
+const mockUseUpdateStatus = vi.hoisted(() => vi.fn())
 
 vi.mock('@/hooks/useRecoveryAutoReload', () => ({
   useRecoveryAutoReload: useRecoveryAutoReloadMock,
@@ -19,6 +20,10 @@ vi.mock('@/hooks/useRecoveryAutoReload', () => ({
 
 vi.mock('@/hooks/useProjects', () => ({
   useProjects: () => mockUseProjects(),
+}))
+
+vi.mock('@/hooks/useUpdateStatus', () => ({
+  useUpdateStatus: () => mockUseUpdateStatus(),
 }))
 
 import { useBackendHealth } from '@/hooks/useBackendHealth'
@@ -118,10 +123,10 @@ function makeUIValue(overrides: Partial<UIContextValue['state']> = {}, dispatch 
   }
 }
 
-function renderShell(uiValue = makeUIValue()) {
+function renderShell(uiValue = makeUIValue(), onOpenAbout?: () => void) {
   return renderWithProviders(
     <UIContext.Provider value={uiValue}>
-      <AppShell>
+      <AppShell onOpenAbout={onOpenAbout}>
         <div>Dashboard</div>
       </AppShell>
     </UIContext.Provider>,
@@ -136,6 +141,7 @@ describe('AppShell', () => {
   beforeEach(() => {
     useRecoveryAutoReloadMock.mockReset()
     mockUseProjects.mockReturnValue({ data: projects })
+    mockUseUpdateStatus.mockReturnValue({ data: undefined })
   })
 
   it('renders a docs link that opens in a new tab', () => {
@@ -145,6 +151,20 @@ describe('AppShell', () => {
     expect(docsLink).toHaveAttribute('href', `${__LOOPTROOP_DOCS_ORIGIN__}/`)
     expect(docsLink).toHaveAttribute('target', '_blank')
     expect(docsLink).toHaveAttribute('rel', expect.stringContaining('noopener'))
+  })
+
+  it('shows a subtle update indicator and opens About from the version', () => {
+    const onOpenAbout = vi.fn()
+    mockUseUpdateStatus.mockReturnValue({
+      data: { updateAvailable: true, latestVersion: '0.6.0' },
+    })
+
+    renderShell(uiValue, onOpenAbout)
+
+    const versionButton = screen.getByRole('button', { name: /update 0\.6\.0 available; open about/i })
+    expect(within(versionButton).getByTestId('update-available-icon')).toBeInTheDocument()
+    fireEvent.click(versionButton)
+    expect(onOpenAbout).toHaveBeenCalledOnce()
   })
 
   it('collapses secondary navigation without overflowing phone and tablet headers', () => {

--- a/src/hooks/useUpdateStatus.ts
+++ b/src/hooks/useUpdateStatus.ts
@@ -1,0 +1,39 @@
+import { useQuery } from '@tanstack/react-query'
+
+export type InstallChannel = 'npm' | 'bun' | 'pnpm' | 'yarn' | 'homebrew' | 'scoop' | 'chocolatey' | 'winget' | 'aur' | 'binary' | 'container' | 'source' | 'unknown'
+
+export interface UpdateStatus {
+  currentVersion: string
+  latestVersion: string | null
+  updateAvailable: boolean
+  checkedAt: string | null
+  installChannel: InstallChannel
+  upgradeCommand: string
+  upgradeFirst?: string
+  postUpgradeCommand?: string
+  upgradeNote?: string
+  release: {
+    version: string
+    name: string
+    url: string
+    publishedAt: string | null
+    notes: string
+  } | null
+}
+
+export const UPDATE_STATUS_QUERY_KEY = ['update-status'] as const
+
+async function fetchUpdateStatus(): Promise<UpdateStatus> {
+  const response = await fetch('/api/health/update')
+  if (!response.ok) throw new Error('Failed to check for LoopTroop updates')
+  return response.json()
+}
+
+export function useUpdateStatus() {
+  return useQuery({
+    queryKey: UPDATE_STATUS_QUERY_KEY,
+    queryFn: fetchUpdateStatus,
+    staleTime: 15 * 60 * 1000,
+    refetchOnWindowFocus: true,
+  })
+}

--- a/tests/doctorCommand.test.ts
+++ b/tests/doctorCommand.test.ts
@@ -5,6 +5,7 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { doctorCommand, runChecks, judgeOpenCode, runProbe } from '../server/cli/doctorCommand'
 import type { DaemonState } from '../server/lib/daemonPaths'
+import { APP_VERSION } from '../server/lib/appVersion'
 
 /**
  * 2.12 contract: doctor tells a user whether this machine can run LoopTroop,
@@ -81,6 +82,45 @@ describe('doctor command', () => {
     const parsed = JSON.parse(stdout.text()) as { ok: boolean; checks: unknown[] }
     expect(typeof parsed.ok).toBe('boolean')
     expect(Array.isArray(parsed.checks)).toBe(true)
+  })
+
+  it('always reports current and latest versions when update status is supplied', async () => {
+    useConfigDir()
+    const stdout = captureStdout()
+    const update = {
+      currentVersion: APP_VERSION,
+      latestVersion: '0.6.0',
+      updateAvailable: true,
+      checkedAt: '2026-08-16T08:00:00.000Z',
+      installChannel: 'npm' as const,
+      upgradeCommand: 'npm install -g looptroop@latest',
+      postUpgradeCommand: 'looptroop restart',
+      release: null,
+    }
+
+    await doctorCommand(false, update)
+
+    expect(stdout.text()).toContain('version')
+    expect(stdout.text()).toContain(`current ${APP_VERSION}; latest 0.6.0 (update available)`)
+    expect(stdout.text()).toContain('npm install -g looptroop@latest')
+    expect(stdout.text()).toContain('looptroop restart')
+  })
+
+  it('includes structured update facts in doctor JSON', async () => {
+    useConfigDir()
+    const stdout = captureStdout()
+    await doctorCommand(true, {
+      currentVersion: APP_VERSION,
+      latestVersion: null,
+      updateAvailable: false,
+      checkedAt: null,
+      installChannel: 'unknown',
+      upgradeCommand: 'See https://www.looptroop.ovh for upgrade instructions',
+      release: null,
+    })
+
+    const payload = JSON.parse(stdout.text()) as { update: { currentVersion: string; latestVersion: null } }
+    expect(payload.update).toEqual(expect.objectContaining({ currentVersion: APP_VERSION, latestVersion: null }))
   })
 
   it('exits zero when nothing is failing', async () => {

--- a/tests/updateCheck.test.ts
+++ b/tests/updateCheck.test.ts
@@ -10,7 +10,7 @@ import {
   readRecordedInstall,
   resolveInstallInfo,
 } from '../server/lib/installChannel'
-import { checkForUpdate, CHECK_INTERVAL_MS, formatUpdateNotice } from '../server/lib/updateCheck'
+import { checkForUpdate, CHECK_INTERVAL_MS, formatUpdateNotice, getUpdateStatus } from '../server/lib/updateCheck'
 
 /**
  * 2.13 contract: the upgrade command shown must match how this copy was
@@ -171,6 +171,16 @@ describe('install channel detection', () => {
       .toBe('npm install -g looptroop@latest')
     expect(getInstallInfo('/opt/homebrew/Cellar/looptroop/9.9.9/libexec/dist/server/cli').upgradeCommand)
       .toBe('brew upgrade looptroop')
+  })
+
+  it('explains what must happen to the running process after each kind of upgrade', () => {
+    expect(getInstallInfo('/usr/local/lib/node_modules/looptroop/dist/server/cli').postUpgradeCommand)
+      .toBe('looptroop restart')
+
+    process.env.LOOPTROOP_CONTAINER = '1'
+    const container = getInstallInfo('/app/dist/server/cli')
+    expect(container.postUpgradeCommand).toBeUndefined()
+    expect(container.upgradeNote).toContain('recreate')
   })
 })
 
@@ -457,6 +467,32 @@ describe('update check', () => {
     expect(notice?.currentVersion).toBe('0.4.1')
   })
 
+  it('returns full GitHub release details and lifecycle guidance for the UI', async () => {
+    const configDir = makeConfigDir()
+    writeFileSync(join(configDir, 'config.json'), JSON.stringify({ install: { channel: 'npm' } }))
+    const status = await getUpdateStatus({
+      currentVersion: '0.4.1',
+      configDir,
+      fetchRelease: async () => ({
+        version: '0.5.0',
+        name: 'LoopTroop 0.5.0',
+        url: 'https://github.com/looptroop-ai/LoopTroop/releases/tag/v0.5.0',
+        publishedAt: '2026-08-16T08:00:00.000Z',
+        notes: 'Everything in the GitHub release body.',
+      }),
+    })
+
+    expect(status).toMatchObject({
+      currentVersion: '0.4.1',
+      latestVersion: '0.5.0',
+      updateAvailable: true,
+      installChannel: 'npm',
+      upgradeCommand: 'npm install -g looptroop@latest',
+      postUpgradeCommand: 'looptroop restart',
+      release: { notes: 'Everything in the GitHub release body.' },
+    })
+  })
+
   it('stays silent when already current', async () => {
     const notice = await checkForUpdate({
       currentVersion: '0.5.0',
@@ -525,14 +561,14 @@ describe('update check', () => {
   })
 
   /**
-   * What a machine that cannot reach the registry paid.
+   * What a machine that cannot reach GitHub paid.
    *
    * Only answers were cached, so a failed lookup left no timestamp to compare
    * against and every command tried again — a fresh request, and its full
    * timeout, on every single `looptroop status` for as long as the machine
    * stayed offline.
    */
-  describe('when the registry cannot be reached', () => {
+  describe('when GitHub cannot be reached', () => {
     it('does not try again within the interval', async () => {
       const configDir = makeConfigDir()
       let calls = 0
@@ -622,7 +658,7 @@ describe('update check', () => {
       })
 
       // Upgrading LoopTroop must not invalidate the cache and send every
-      // installed copy back to the registry on its next command.
+      // installed copy back to GitHub on its next command.
       expect(calls).toBe(0)
       expect(notice?.latestVersion).toBe('0.5.0')
     })
@@ -638,5 +674,19 @@ describe('update check', () => {
     expect(text).toContain('0.5.0')
     expect(text).toContain('0.4.1')
     expect(text).toContain('npm install -g looptroop@latest')
+  })
+
+  it('prints post-upgrade and channel notes as separate cross-shell-safe lines', () => {
+    const text = formatUpdateNotice({
+      currentVersion: '0.4.1',
+      latestVersion: '0.5.0',
+      upgradeFirst: 'looptroop stop',
+      upgradeCommand: 'winget upgrade LoopTroopAI.LoopTroop',
+      postUpgradeCommand: 'looptroop open',
+      upgradeNote: 'Restart guidance.',
+    })
+
+    expect(text).toContain('  looptroop stop\n  winget upgrade LoopTroopAI.LoopTroop\n  looptroop open\n')
+    expect(text).toContain('Restart guidance.')
   })
 })


### PR DESCRIPTION
## What changed

- replace the npm-only daily version notice with a shared 15-minute latest-published-GitHub-release status
- surface update availability from `--version`, `status`, `start`, `open`, Doctor, the header version, and About
- keep `status --json` and `doctor --json` machine-readable while adding structured update facts
- show install-channel-specific ordered upgrade, restart, publication-lag, standalone-installer, and container-recreation guidance
- expose full GitHub release metadata through `/api/health/update` and an accessible About changelog hover/focus card
- preserve package-launcher and standalone-binary entry behavior while making the CLI main function directly testable

## Why

Users previously discovered updates only from human-readable `status` while a daemon was running, and the npm registry version had no release details. The result could miss stopped daemons, JSON consumers, normal launch paths, and non-npm installation lifecycle requirements.

## Impact

LoopTroop remains notify-only and never rewrites itself. GitHub failures retain the last known release and cache failed attempts, so offline commands are not repeatedly delayed. Existing daemon processes must be restarted after ordinary package replacement; standalone and container behavior is explained explicitly.

## Validation

- focused update/CLI/Doctor/route/UI tests: 133 passed
- full Vitest suite
- `npm run typecheck`
- `npm run lint`
- `npm run build`
- `npm run verify:version`
- `npm run installers:check`
- `npm run licenses:check`
- `npm run verify:package`
- `npm run verify:install`
- `npm run verify:installer`
- bundle build + bundle smoke test
- `npm run verify:readonly`
- Docker image build + full container smoke test
- live isolated `--version`, `status --json`, and `doctor --json` checks