### PR TITLE
chore(ci): lint the workflows, widen attestation, drop the dead bundle zip

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,47 @@ env:
   NPM_CONFIG_AUDIT: 'false'
 
 jobs:
+  # 4,400+ lines of workflow YAML, most of it inline bash and PowerShell that no
+  # other check reads. `npm run lint` covers the application and never opens
+  # `.github/`, so a typo'd expression, an unreachable `if:`, a shell variable
+  # that is never quoted, or a job referencing an output that does not exist all
+  # reach main and are discovered by a release that half-runs.
+  #
+  # actionlint parses the workflow schema, checks every `${{ }}` expression, and
+  # hands `run:` blocks to shellcheck.
+  workflows:
+    name: Workflow lint
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+      - name: Install actionlint
+        run: |
+          set -euo pipefail
+          # Pinned by version and verified by digest: this downloads a binary and
+          # runs it, which is the shape that had to be removed from the Windows
+          # bun install for the same reason.
+          version=1.7.12
+          sha256=8aca8db96f1b94770f1b0d72b6dddcb1ebb8123cb3712530b08cc387b349a3d8
+          url="https://github.com/rhysd/actionlint/releases/download/v${version}/actionlint_${version}_linux_amd64.tar.gz"
+          curl --fail --silent --show-error --location --retry 3 -o /tmp/actionlint.tgz "${url}"
+          echo "${sha256}  /tmp/actionlint.tgz" | sha256sum --check --status
+          tar -xzf /tmp/actionlint.tgz -C /tmp actionlint
+
+      # shellcheck ships with the runner image, and actionlint silently skips
+      # shell linting when it is missing — losing half the value of this job
+      # without failing it. Checked explicitly so that stays impossible.
+      - name: Check shellcheck is available
+        run: shellcheck --version
+
+      # `-S warning` because every `info` and `style` finding in these workflows
+      # today is correct code: SC2016 fires on the single-quoted `node -e '…'`
+      # blocks, where expansion is exactly what must not happen and double quotes
+      # would break the embedded JavaScript. Errors and warnings still fail.
+      - name: Lint the workflows
+        run: /tmp/actionlint -color -shellcheck="shellcheck -S warning"
+
   verify:
     name: Verify (ubuntu, Node 24.15.0)
     runs-on: ubuntu-latest
@@ -435,27 +476,19 @@ jobs:
           set -euo pipefail
           node scripts/build-bundle.mjs --out "${RUNNER_TEMP}/bundle-a"
           node scripts/build-bundle.mjs --out "${RUNNER_TEMP}/bundle-b"
-          # Both archives, not only the tarball. The zip carries the same tree
-          # for WinGet, a manifest records its hash too, and ZIP is the format
-          # more likely to drift — it stores DOS local time rather than an
-          # epoch, so a timezone difference alone would move the digest.
-          for ext in tar.gz zip; do
-            a=$(sha256sum "${RUNNER_TEMP}"/bundle-a/*."${ext}" | cut -d' ' -f1)
-            b=$(sha256sum "${RUNNER_TEMP}"/bundle-b/*."${ext}" | cut -d' ' -f1)
-            if [ "${a}" != "${b}" ]; then
-              echo "::error::Two builds of this commit produced different .${ext} bundles (${a} vs ${b})."
-              exit 1
-            fi
-            echo "Reproducible .${ext}: ${a}"
-          done
+          a=$(sha256sum "${RUNNER_TEMP}"/bundle-a/*.tar.gz | cut -d' ' -f1)
+          b=$(sha256sum "${RUNNER_TEMP}"/bundle-b/*.tar.gz | cut -d' ' -f1)
+          if [ "${a}" != "${b}" ]; then
+            echo "::error::Two builds of this commit produced different bundles (${a} vs ${b})."
+            exit 1
+          fi
+          echo "Reproducible: ${a}"
 
       - name: Upload the bundle
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: bundle
-          path: |
-            ${{ runner.temp }}/bundle-a/*.tar.gz
-            ${{ runner.temp }}/bundle-a/*.zip
+          path: ${{ runner.temp }}/bundle-a/*.tar.gz
           if-no-files-found: error
           retention-days: 7
 

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -216,11 +216,25 @@ jobs:
             echo
             cat /tmp/release-notes.md
           } > /tmp/pr-body.md
-          gh pr create \
-            --base main \
-            --head "release/v${VERSION}" \
-            --title "release: v${VERSION}" \
-            --body-file /tmp/pr-body.md
+          # The branch above is force-pushed, so a re-run for the same version
+          # is expected — and `gh pr create` fails outright when a PR for that
+          # head already exists. A release workflow is exactly the one that gets
+          # re-run under stress, so an existing PR is updated in place instead:
+          # same number, same URL, refreshed notes.
+          existing=$(gh pr list --head "release/v${VERSION}" --state open \
+            --json number --jq '.[0].number // empty')
+          if [ -n "${existing}" ]; then
+            gh pr edit "${existing}" \
+              --title "release: v${VERSION}" \
+              --body-file /tmp/pr-body.md
+            echo "Updated existing pull request #${existing}."
+          else
+            gh pr create \
+              --base main \
+              --head "release/v${VERSION}" \
+              --title "release: v${VERSION}" \
+              --body-file /tmp/pr-body.md
+          fi
 
       - name: Dry run summary
         if: ${{ steps.mode.outputs.dry_run == 'true' }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -285,7 +285,7 @@ jobs:
       # job-level block *replaces* the workflow default rather than adding to
       # it — anything unlisted becomes `none`, and the checkout would fail.
       - name: Attest the archive
-        uses: actions/attest-build-provenance@977bb373ede98d70efdf65b84cb5f73e068dcc2a # v3
+        uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4.2.2
         with:
           subject-path: |
             ${{ runner.temp }}/binary/*.tar.gz
@@ -318,14 +318,20 @@ jobs:
           || (needs.binary.result == 'skipped' && needs.detect.outputs.skip_binaries == 'true'))
     runs-on: ubuntu-latest
     timeout-minutes: 25
+    # Same three as the binary job, and for the same reason: attestation needs
+    # an OIDC token to sign with and the attestations scope to store the result.
+    # A job-level block replaces the workflow default rather than adding to it,
+    # so `contents: read` is listed or the checkout loses its read access.
+    permissions:
+      contents: read
+      id-token: write
+      attestations: write
     outputs:
       tarball: ${{ steps.manifest.outputs.tarball }}
       sha256: ${{ steps.manifest.outputs.sha256 }}
       integrity: ${{ steps.manifest.outputs.integrity }}
       bundle: ${{ steps.manifest.outputs.bundle }}
       bundle_sha256: ${{ steps.manifest.outputs.bundle_sha256 }}
-      bundle_zip: ${{ steps.manifest.outputs.bundle_zip }}
-      bundle_zip_sha256: ${{ steps.manifest.outputs.bundle_zip_sha256 }}
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
@@ -419,11 +425,9 @@ jobs:
         run: |
           set -euo pipefail
           tarball="looptroop-${{ needs.detect.outputs.version }}.tgz"
+          # What Homebrew, Scoop and Chocolatey fetch. WinGet does not: its
+          # portable installer takes the standalone Windows binary instead.
           bundle="looptroop-${{ needs.detect.outputs.version }}-bundle.tar.gz"
-          # The same tree in two archive formats. The tarball is what Homebrew,
-          # Scoop and Chocolatey fetch; the zip exists because WinGet's archive
-          # installer type reads ZIP and nothing else.
-          zip="looptroop-${{ needs.detect.outputs.version }}-bundle.zip"
           # The binaries are named per target and there is one manifest, so they
           # are collected by glob rather than listed: a target added later must
           # not need this line edited, and a target that failed to upload must
@@ -440,7 +444,7 @@ jobs:
             echo "::warning::Writing a manifest with no standalone binaries, by operator request."
           fi
           npm run release:manifest -- "${tarball}" \
-            --asset "${bundle}" --asset "${zip}" --asset install.sh --asset install.ps1 \
+            --asset "${bundle}" --asset install.sh --asset install.ps1 \
             "${binaries[@]}"
           node -e '
             const m = JSON.parse(require("node:fs").readFileSync("release-manifest.json","utf8"))
@@ -451,11 +455,30 @@ jobs:
             const bundle = Object.keys(m.assets).find((n) => n.endsWith("-bundle.tar.gz"))
             out.write(`bundle=${bundle}\n`)
             out.write(`bundle_sha256=${m.assets[bundle].sha256}\n`)
-            const zip = Object.keys(m.assets).find((n) => n.endsWith("-bundle.zip"))
-            out.write(`bundle_zip=${zip}\n`)
-            out.write(`bundle_zip_sha256=${m.assets[zip].sha256}\n`)
             out.end()
           '
+
+      # The binaries are attested where they are built, one job per target. The
+      # rest of what a user can install is attested here, because this is the
+      # only job that has all of it in one place.
+      #
+      # `install.sh` and `install.ps1` matter most: they are fetched over the
+      # network and piped straight into a shell, which is the one asset where a
+      # substitution would execute rather than merely install. The manifest and
+      # checksums are attested too — they are what a repair job trusts months
+      # later to decide which bytes a release published.
+      #
+      # Verified with: gh attestation verify <file> --repo looptroop-ai/LoopTroop
+      - name: Attest the release assets
+        uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4.2.2
+        with:
+          subject-path: |
+            looptroop-*.tgz
+            looptroop-*-bundle.tar.gz
+            install.sh
+            install.ps1
+            release-manifest.json
+            checksums.sha256
 
       - name: Upload the release artefacts
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
@@ -464,7 +487,6 @@ jobs:
           path: |
             looptroop-*.tgz
             looptroop-*-bundle.tar.gz
-            looptroop-*-bundle.zip
             looptroop-*-linux-*.tar.gz
             looptroop-*-darwin-*.tar.gz
             looptroop-*-win-*.zip
@@ -1629,11 +1651,12 @@ jobs:
   # packaging bug gets fixed for an old version) and occasionally not.
   #
   # Attaching the descriptors would close that, at the cost of three more
-  # release assets and a Windows job before `finalize`. It is not done yet
-  # because the first real release has not run: adding a new gate to an
-  # unproven publish path trades a rare, recoverable drift for a common,
-  # release-blocking failure. Revisit once a stable release has published to
-  # all three channels.
+  # release assets and a Windows job before `finalize`. Still not done, and the
+  # original condition for revisiting — "once a stable release has published to
+  # all three channels" — has not been met: Homebrew and Scoop publish, while
+  # Chocolatey and WinGet are still awaiting first acceptance upstream. Until a
+  # release has actually landed on all of them there is no repair history to
+  # judge the drift against, so revisit when that is true rather than on a date.
   #
   # The nupkg is separate: it is not byte-reproducible, but a Chocolatey version
   # is immutable once accepted — there is no such thing as re-pushing the same
@@ -2187,12 +2210,15 @@ jobs:
             echo "  \`${VERSION}\`. It rebuilds the image from the release assets and re-runs"
             echo "  the same tag and verify steps, so it works long after the workflow"
             echo "  artefacts for this run have expired."
-            echo "- **publish-\*** — dispatch \`channel-republish.yml\` with version"
-            echo "  \`${VERSION}\` and the channel that failed. It re-derives the descriptor"
-            echo "  from the published release, so it too outlives this run's artefacts."
-            echo "  A channel already carrying this version is left alone unless the"
-            echo "  dispatch is given \`force\`, which exists for a descriptor that was"
-            echo "  published wrong rather than not at all."
+            echo "- **publish-homebrew / publish-scoop / publish-chocolatey / publish-winget**"
+            echo "  — dispatch \`channel-republish.yml\` with version \`${VERSION}\` and the"
+            echo "  channel that failed. It re-derives the descriptor from the published"
+            echo "  release, so it too outlives this run's artefacts. A channel already"
+            echo "  carrying this version is left alone unless the dispatch is given"
+            echo "  \`force\`, which exists for a descriptor that was published wrong"
+            echo "  rather than not at all."
+            echo "- **publish-aur** — \`channel-republish.yml\` does *not* cover the AUR."
+            echo "  Re-run this job from the release run, or push the PKGBUILD by hand."
           } > /tmp/issue.md
 
           # --repo on every call: this job deliberately has no checkout, and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,16 +12,24 @@ Unreleased changes appear first and represent commits that have not yet been inc
 ### Summary
 - Remote development works from the advertised LAN and trusted Tailscale URLs again, including ticket creation and every other write action.
 - New releases are now visible wherever users naturally look: the core CLI commands, Doctor, the header version, and an install-aware About window with full GitHub release notes.
+- Every downloadable release asset now carries signed build provenance, not just the standalone binaries — including the two installer scripts, which are the assets a user pipes into a shell.
 
 ### Added
 - Added one shared published-release status for the CLI and interface. `looptroop --version`, `status`, `start`, and `open` now report a notice on **stderr** whenever a newer GitHub release exists, leaving stdout byte-for-byte as it was so scripts that read `looptroop --version` keep working; `doctor` always reports the current and latest known versions, and both `status --json` and `doctor --json` expose the same structured update facts without adding non-JSON output.
 - Added an Updates section to About with the current and latest versions, the detected installation channel, exact ordered upgrade commands, restart or container-recreation guidance, and a Changelog control whose hover/focus card shows the complete latest GitHub release body. The header version now opens About and gains a quiet monochrome update icon only when a newer release is available.
+- Extended artefact attestation from the standalone binaries to the npm tarball, the bundle, `install.sh`, `install.ps1`, `release-manifest.json` and `checksums.sha256`. Any of them can be checked with `gh attestation verify <file> --repo looptroop-ai/LoopTroop`, which now covers the installer scripts a user executes rather than only the executables they unpack.
+- Added workflow linting to CI. `actionlint` checks the schema and every `${{ }}` expression across all five workflows, and hands their inline shell to ShellCheck — 4,400 lines that no existing check read, where a bad expression or an unquoted variable previously reached `main` and surfaced as a half-finished release.
 
 ### Changed
 - Release discovery now follows the latest published GitHub release rather than npm alone, so the version users are shown has public release notes and is not announced while its GitHub release is still a draft. Results and failed attempts are cached for 15 minutes so each requested command can report updates without repeatedly waiting on GitHub when offline.
 - Upgrade guidance now includes what happens after package replacement: ordinary package-manager and source installations restart the daemon to load the new code, the transactional standalone installer explains that it handles the restart itself, WinGet opens LoopTroop after replacing the stopped executable, and containers explicitly require recreation after pulling the image.
 
+### Removed
+- Removed the `-bundle.zip` release asset. It was built, hashed, recorded in the release manifest and uploaded on every release, but nothing consumed it: WinGet installs the standalone Windows binary archive instead, which it has done since WinGet support landed. Dropping it also removes Info-ZIP as a build requirement. The bundle is still published as `-bundle.tar.gz`, and the channels that use it are unaffected.
+
 ### Fixed
+- Fixed the release failure report telling operators to repair a failed `publish-aur` with `channel-republish.yml`, which has no AUR support and never had. The report now names the four channels that workflow does cover and says plainly that the AUR needs the release job re-run or a manual push.
+- Fixed the release PR workflow failing when re-run for a version whose pull request already exists. It now updates the existing pull request in place — same number, same URL, refreshed notes — rather than aborting on `gh pr create`.
 - Fixed development API writes failing with `Forbidden: cross-origin requests are not accepted` when the interface was opened through a LAN address or a trusted same-origin reverse proxy such as Tailscale Serve. Vite now translates the browser-visible origin only when the browser vouches that the request is same-origin and that origin exactly matches the incoming frontend host. Requests from unrelated pages keep their original origin and remain blocked by the backend guard; the production daemon and its loopback-only boundary are unchanged.
 
 ## 0.5.5 (2026-08-14)

--- a/scripts/build-bundle.mjs
+++ b/scripts/build-bundle.mjs
@@ -56,41 +56,6 @@ function run(command, args, cwd) {
   return execFileSync(command, args, { cwd, encoding: 'utf8', stdio: ['ignore', 'pipe', 'inherit'] })
 }
 
-/**
- * The same staged tree as a ZIP, for WinGet.
- *
- * Not a convenience: WinGet's archive installer type reads ZIP and nothing
- * else, so a `.tar.gz` is not a format it can open at all. Both archives carry
- * identical contents, so a user gets the same bundle whichever channel brought
- * it.
- *
- * Reproducible for the same reason the tarball is — a manifest records this
- * hash and descriptors point at it — which needs three things ZIP does not do
- * by default:
- *
- *   - Entries listed explicitly and sorted, rather than letting `zip -r` walk
- *     the tree. `readdir` order is not guaranteed, and an archive whose entry
- *     order moves between builds hashes differently for no reason.
- *   - `-X`, to leave out uid, gid and the extra timestamp fields.
- *   - `TZ=UTC`. ZIP stores DOS local time, not an epoch, so the same file
- *     yields different bytes in different timezones. `FIXED_MTIME` is midnight
- *     on 1980-01-01 UTC, which is exactly the DOS epoch — west of Greenwich it
- *     would fall *before* it and be clamped.
- */
-function writeZip(stagingRoot, zipPath) {
-  const entries = []
-  walk(join(stagingRoot, 'looptroop'), (full, entry) => {
-    if (entry.isDirectory() || entry.isFile()) entries.push(relative(stagingRoot, full))
-  })
-  entries.sort()
-
-  execFileSync('zip', ['-X', '-9', '-q', '-@', zipPath], {
-    cwd: stagingRoot,
-    input: `${entries.join('\n')}\n`,
-    env: { ...process.env, TZ: 'UTC' },
-    stdio: ['pipe', 'inherit', 'inherit'],
-  })
-}
 
 function walk(dir, onEntry) {
   for (const entry of readdirSync(dir, { withFileTypes: true })) {
@@ -267,8 +232,6 @@ const outDir = resolve(outIndex === -1 ? join(repoRoot, 'dist-bundle') : args[ou
 const version = JSON.parse(readFileSync(join(repoRoot, 'package.json'), 'utf8')).version
 const archiveName = `looptroop-${version}-bundle.tar.gz`
 const archivePath = join(outDir, archiveName)
-const zipName = `looptroop-${version}-bundle.zip`
-const zipPath = join(outDir, zipName)
 
 if (!existsSync(join(repoRoot, 'dist', 'server', 'cli', 'launcher.cjs'))) {
   fail('dist/ is missing or incomplete.', 'Run `npm run build` first.')
@@ -279,14 +242,6 @@ if (!existsSync(join(repoRoot, 'dist', 'server', 'cli', 'launcher.cjs'))) {
 // whose hash changes for no reason.
 const tarVersion = run('tar', ['--version']).split('\n')[0] ?? ''
 if (!/GNU tar/.test(tarVersion)) fail(`GNU tar is required to build a reproducible archive; found "${tarVersion}".`)
-
-// Info-ZIP, for the WinGet archive. Checked up front beside tar rather than
-// discovered after several minutes of `npm ci`.
-try {
-  run('zip', ['-v'])
-} catch {
-  fail('`zip` is required to build the WinGet archive.', 'On Debian and Ubuntu: apt-get install zip')
-}
 
 const stagingRoot = mkdtempSync(join(tmpdir(), 'looptroop-bundle-'))
 const stagingDir = join(stagingRoot, 'looptroop')
@@ -339,13 +294,8 @@ try {
     'looptroop',
   ], repoRoot)
 
-  rmSync(zipPath, { force: true })
-  writeZip(stagingRoot, zipPath)
-
   const bytes = readFileSync(archivePath)
   const sha256 = createHash('sha256').update(bytes).digest('hex')
-  const zipBytes = readFileSync(zipPath)
-  const zipSha256 = createHash('sha256').update(zipBytes).digest('hex')
 
   process.stdout.write([
     '',
@@ -354,11 +304,6 @@ try {
     `bytes       ${bytes.length}`,
     `sha256      ${sha256}`,
     `wrote       ${archivePath}`,
-    '',
-    `winget zip  ${zipName}`,
-    `bytes       ${zipBytes.length}`,
-    `sha256      ${zipSha256}`,
-    `wrote       ${zipPath}`,
     '',
   ].join('\n'))
 } finally {

--- a/scripts/channel-inputs.ts
+++ b/scripts/channel-inputs.ts
@@ -56,16 +56,12 @@ if (bundle === undefined) {
   )
 }
 
-// Absent from every release before WinGet existed, so its absence is reported
-// as empty rather than fatal: Homebrew, Scoop and Chocolatey can still be
-// repaired for those versions, and only the WinGet job needs to refuse.
-const zip = Object.keys(assets).find((name) => name.endsWith('-bundle.zip')) ?? null
-
 // The standalone Windows binary, which is what WinGet installs — its portable
 // installer accepts an `.exe` and nothing else, so it cannot take the bundle
 // the other three channels use. Absent from releases published before the
-// binaries existed, and reported as empty rather than fatal for the same
-// reason the bundle zip is.
+// binaries existed, so its absence is reported as empty rather than fatal:
+// Homebrew, Scoop and Chocolatey can still be repaired for those versions, and
+// only the WinGet job needs to refuse.
 const winBinary = Object.keys(assets).find((name) => /-win-x64\.zip$/.test(name)) ?? null
 
 const output = {
@@ -73,9 +69,6 @@ const output = {
   bundle,
   sha256: assets[bundle]!.sha256,
   url: `https://github.com/${repo}/releases/download/v${manifest.version}/${bundle}`,
-  zip: zip ?? '',
-  zip_sha256: zip === null ? '' : assets[zip]!.sha256,
-  zip_url: zip === null ? '' : `https://github.com/${repo}/releases/download/v${manifest.version}/${zip}`,
   win_binary: winBinary ?? '',
   win_binary_sha256: winBinary === null ? '' : assets[winBinary]!.sha256,
   win_binary_url: winBinary === null ? '' : `https://github.com/${repo}/releases/download/v${manifest.version}/${winBinary}`,

--- a/scripts/package-manifests.ts
+++ b/scripts/package-manifests.ts
@@ -199,16 +199,6 @@ export function bundleFileName(version: string): string {
   return `looptroop-${version}-bundle.tar.gz`
 }
 
-/**
- * The same bundle as a ZIP, which is the only archive format WinGet reads.
- *
- * `InstallerType: zip` means ZIP; there is no tar.gz option, so this is a
- * second asset rather than a preference.
- */
-export function bundleZipFileName(version: string): string {
-  return `looptroop-${version}-bundle.zip`
-}
-
 /** The standalone Windows binary's archive, which is what WinGet installs. */
 export function windowsBinaryZipName(version: string): string {
   return `looptroop-${version}-win-x64.zip`

--- a/tests/packageManifests.test.ts
+++ b/tests/packageManifests.test.ts
@@ -5,7 +5,6 @@ import { fileURLToPath } from 'node:url'
 import {
   BUNDLE_ROOT,
   bundleFileName,
-  bundleZipFileName,
   CHANNEL_MARKER,
   DESCRIPTOR_PATH,
   parseDescriptor,
@@ -354,7 +353,10 @@ describe('the WinGet manifests', () => {
   it('points at the Windows binary archive, not the bundle', () => {
     const installer = rendered()[`${WINGET_IDENTIFIER}.installer.yaml`]!
     expect(installer).toContain(windowsBinaryZipName('9.9.9'))
-    expect(installer).not.toContain(bundleZipFileName('9.9.9'))
+    // The bundle ZIP this once pointed at no longer exists in any form, so the
+    // assertion is against the name rather than a helper: nothing should
+    // reintroduce a second archive for WinGet to read.
+    expect(installer).not.toContain('looptroop-9.9.9-bundle.zip')
     expect(installer).not.toContain(bundleFileName('9.9.9'))
     expect(installer).toContain('InstallerType: zip')
   })


### PR DESCRIPTION
Acts on a workflow audit covering all five files in `.github/workflows`. Every finding was checked against the code before implementing; two of the audit's claims turned out to be wrong and are not acted on.

## Implemented

**Workflow linting** — 4,400 lines of YAML that no check ever read. `actionlint` now validates the schema and every `${{ }}` expression, and hands `run:` blocks to ShellCheck. Pinned to 1.7.12 and verified by digest, since it downloads and runs a binary. ShellCheck's presence is asserted explicitly, because actionlint skips shell linting *silently* when it's missing.

The floor is `-S warning`: all twelve current findings are `info`/`style`, and every one is correct code — SC2016 firing on single-quoted `node -e '…'` blocks where expansion must not happen.

**`-bundle.zip` removed** — built, hashed, written into the release manifest, uploaded, exported as two job outputs and threaded through `channel-inputs.ts`, with no consumer anywhere. WinGet installs the standalone Windows binary archive and has since WinGet support landed. Also drops Info-ZIP as a build dependency. Two downstream uses the audit missed are fixed: CI's `for ext in tar.gz zip` reproducibility loop, and a manifest test importing the deleted helper.

**Attestation widened** — was only the four binary archives. Now also the npm tarball, bundle, `install.sh`, `install.ps1`, `release-manifest.json` and `checksums.sha256`. The installers matter most: they're piped into a shell, the one asset class where substitution executes rather than merely installs. `attest-build-provenance` v3 → v4.2.2 (a compatible wrapper, not a breaking change).

**AUR repair instruction corrected** — the failure report told operators to repair any `publish-*` failure with `channel-republish.yml`, which has no AUR path.

**Release PR reruns** — `gh pr create` failed outright when a PR for the head already existed; it now edits in place.

## Audit claims that were wrong

- `docker/setup-buildx-action` is **not** "one patch behind v4.2.2" — the repo pins v4.2.0, which is current.
- WinGet schema: 1.6.0 is behind, but **1.28.0** is current, not 1.12.0. A bump needs `winget validate` on Windows and touches a queued upstream submission.

## Deferred

Published-installer smoke, immutable releases, container build cache, live channel verification — real gaps, but each is new surface rather than a fix, and the first two can only be proved by a real release.

## Impact

`-bundle.zip` disappears from future releases. Nothing in this repo, its workflows or its docs consumed it.

## Checks

actionlint (with ShellCheck) 0 · lint 0 · typecheck 0 · 3351 tests · `verify:version` 0 · `installers:check` 0 · bundle byte-identical across two clean builds

> Stacked on `feat/update-availability-surfaces` (#49) because both touch `CHANGELOG.md`. Merge #49 first and this becomes a clean diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)