### PR TITLE
chore(release): bump version to 0.5.6

### DIFF
--- a/.github/releases/0.5.6.md
+++ b/.github/releases/0.5.6.md
@@ -1,0 +1,31 @@
+## 0.5.6 (2026-08-17)
+
+
+### Summary
+- Remote development works from the advertised LAN and trusted Tailscale URLs again, including ticket creation and every other write action.
+- New releases are now visible wherever users naturally look: the core CLI commands, Doctor, the header version, and an install-aware About window with full GitHub release notes.
+- Installing now points you at the interface with `looptroop open`, every command explains itself with `--help`, and `doctor` reports each tool's version against the newest published one.
+- Every downloadable release asset now carries signed build provenance, not just the standalone binaries — including the two installer scripts, which are the assets a user pipes into a shell.
+
+### Added
+- Added one shared published-release status for the CLI and interface. `looptroop --version`, `status`, `start`, and `open` now report a notice on **stderr** whenever a newer GitHub release exists, leaving stdout byte-for-byte as it was so scripts that read `looptroop --version` keep working; `doctor` always reports the current and latest known versions, and both `status --json` and `doctor --json` expose the same structured update facts without adding non-JSON output.
+- Added an Updates section to About with the current and latest versions, the detected installation channel, exact ordered upgrade commands, restart or container-recreation guidance, and a Changelog control whose hover/focus card shows the complete latest GitHub release body. The header version now opens About and gains a quiet monochrome update icon only when a newer release is available.
+- Extended artefact attestation from the standalone binaries to the npm tarball, the bundle, `install.sh`, `install.ps1`, `release-manifest.json` and `checksums.sha256`. Any of them can be checked with `gh attestation verify <file> --repo looptroop-ai/LoopTroop`, which now covers the installer scripts a user executes rather than only the executables they unpack.
+- Added `looptroop <command> --help`. Every command now documents its own options, what it does with them, and which command to reach for instead — more than fits in the one-screen summary `looptroop --help` prints.
+- Added npm to `doctor`, which never checked it, and a newest-published version beside LoopTroop, Node, npm and the OpenCode CLI. Nothing is shown when you already have the newest, so the only versions that draw the eye are ones you could act on. Those lookups are cached for fifteen minutes, failures included, and never delay the local checks.
+- Added workflow linting to CI. `actionlint` checks the schema and every `${{ }}` expression across all five workflows, and hands their inline shell to ShellCheck — 4,400 lines that no existing check read, where a bad expression or an unquoted variable previously reached `main` and surfaced as a half-finished release.
+
+### Changed
+- The first thing suggested after installing is now `looptroop open` rather than `looptroop setup`. LoopTroop is used through its interface, and `open` starts it and lands you there; `setup` attaches a project from the terminal, which many people never need. `open` also leads the command list.
+- `doctor` marks something missing with `✗` and something present-but-unhappy with `!`, because "gh is not installed" and "gh is not signed in" want different fixes. Which checks fail, and so the exit code scripts gate on, is unchanged. It also names the install method with the upgrade command on its own line, says that the schema version belongs to the database and where that database is, and reports "no failed start on record" rather than a phrase that read like a missing value.
+- Release discovery now follows the latest published GitHub release rather than npm alone, so the version users are shown has public release notes and is not announced while its GitHub release is still a draft. Results and failed attempts are cached for 15 minutes so each requested command can report updates without repeatedly waiting on GitHub when offline.
+- Upgrade guidance now includes what happens after package replacement: ordinary package-manager and source installations restart the daemon to load the new code, the transactional standalone installer explains that it handles the restart itself, WinGet opens LoopTroop after replacing the stopped executable, and containers explicitly require recreation after pulling the image.
+
+### Removed
+- Removed the `-bundle.zip` release asset. It was built, hashed, recorded in the release manifest and uploaded on every release, but nothing consumed it: WinGet installs the standalone Windows binary archive instead, which it has done since WinGet support landed. Dropping it also removes Info-ZIP as a build requirement. The bundle is still published as `-bundle.tar.gz`, and the channels that use it are unaffected.
+
+### Fixed
+- Fixed `status` and `doctor` reporting "not running" to someone looking straight at the interface. Run from a checkout, `npm run dev` serves the interface through Vite and registers no daemon, so both commands were answering truthfully about something the reader was not asking about. Both now detect the development server and say which of the two they mean.
+- Fixed the release failure report telling operators to repair a failed `publish-aur` with `channel-republish.yml`, which has no AUR support and never had. The report now names the four channels that workflow does cover and says plainly that the AUR needs the release job re-run or a manual push.
+- Fixed the release PR workflow failing when re-run for a version whose pull request already exists. It now updates the existing pull request in place — same number, same URL, refreshed notes — rather than aborting on `gh pr create`.
+- Fixed development API writes failing with `Forbidden: cross-origin requests are not accepted` when the interface was opened through a LAN address or a trusted same-origin reverse proxy such as Tailscale Serve. Vite now translates the browser-visible origin only when the browser vouches that the request is same-origin and that origin exactly matches the incoming frontend host. Requests from unrelated pages keep their original origin and remain blocked by the backend guard; the production daemon and its loopback-only boundary are unchanged.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,18 +9,26 @@ Unreleased changes appear first and represent commits that have not yet been inc
 
 > Changes merged since the last versioned release that have not yet shipped in a tagged version.
 
+## 0.5.6 (2026-08-17)
+
+
 ### Summary
 - Remote development works from the advertised LAN and trusted Tailscale URLs again, including ticket creation and every other write action.
 - New releases are now visible wherever users naturally look: the core CLI commands, Doctor, the header version, and an install-aware About window with full GitHub release notes.
+- Installing now points you at the interface with `looptroop open`, every command explains itself with `--help`, and `doctor` reports each tool's version against the newest published one.
 - Every downloadable release asset now carries signed build provenance, not just the standalone binaries — including the two installer scripts, which are the assets a user pipes into a shell.
 
 ### Added
 - Added one shared published-release status for the CLI and interface. `looptroop --version`, `status`, `start`, and `open` now report a notice on **stderr** whenever a newer GitHub release exists, leaving stdout byte-for-byte as it was so scripts that read `looptroop --version` keep working; `doctor` always reports the current and latest known versions, and both `status --json` and `doctor --json` expose the same structured update facts without adding non-JSON output.
 - Added an Updates section to About with the current and latest versions, the detected installation channel, exact ordered upgrade commands, restart or container-recreation guidance, and a Changelog control whose hover/focus card shows the complete latest GitHub release body. The header version now opens About and gains a quiet monochrome update icon only when a newer release is available.
 - Extended artefact attestation from the standalone binaries to the npm tarball, the bundle, `install.sh`, `install.ps1`, `release-manifest.json` and `checksums.sha256`. Any of them can be checked with `gh attestation verify <file> --repo looptroop-ai/LoopTroop`, which now covers the installer scripts a user executes rather than only the executables they unpack.
+- Added `looptroop <command> --help`. Every command now documents its own options, what it does with them, and which command to reach for instead — more than fits in the one-screen summary `looptroop --help` prints.
+- Added npm to `doctor`, which never checked it, and a newest-published version beside LoopTroop, Node, npm and the OpenCode CLI. Nothing is shown when you already have the newest, so the only versions that draw the eye are ones you could act on. Those lookups are cached for fifteen minutes, failures included, and never delay the local checks.
 - Added workflow linting to CI. `actionlint` checks the schema and every `${{ }}` expression across all five workflows, and hands their inline shell to ShellCheck — 4,400 lines that no existing check read, where a bad expression or an unquoted variable previously reached `main` and surfaced as a half-finished release.
 
 ### Changed
+- The first thing suggested after installing is now `looptroop open` rather than `looptroop setup`. LoopTroop is used through its interface, and `open` starts it and lands you there; `setup` attaches a project from the terminal, which many people never need. `open` also leads the command list.
+- `doctor` marks something missing with `✗` and something present-but-unhappy with `!`, because "gh is not installed" and "gh is not signed in" want different fixes. Which checks fail, and so the exit code scripts gate on, is unchanged. It also names the install method with the upgrade command on its own line, says that the schema version belongs to the database and where that database is, and reports "no failed start on record" rather than a phrase that read like a missing value.
 - Release discovery now follows the latest published GitHub release rather than npm alone, so the version users are shown has public release notes and is not announced while its GitHub release is still a draft. Results and failed attempts are cached for 15 minutes so each requested command can report updates without repeatedly waiting on GitHub when offline.
 - Upgrade guidance now includes what happens after package replacement: ordinary package-manager and source installations restart the daemon to load the new code, the transactional standalone installer explains that it handles the restart itself, WinGet opens LoopTroop after replacing the stopped executable, and containers explicitly require recreation after pulling the image.
 
@@ -28,6 +36,7 @@ Unreleased changes appear first and represent commits that have not yet been inc
 - Removed the `-bundle.zip` release asset. It was built, hashed, recorded in the release manifest and uploaded on every release, but nothing consumed it: WinGet installs the standalone Windows binary archive instead, which it has done since WinGet support landed. Dropping it also removes Info-ZIP as a build requirement. The bundle is still published as `-bundle.tar.gz`, and the channels that use it are unaffected.
 
 ### Fixed
+- Fixed `status` and `doctor` reporting "not running" to someone looking straight at the interface. Run from a checkout, `npm run dev` serves the interface through Vite and registers no daemon, so both commands were answering truthfully about something the reader was not asking about. Both now detect the development server and say which of the two they mean.
 - Fixed the release failure report telling operators to repair a failed `publish-aur` with `channel-republish.yml`, which has no AUR support and never had. The report now names the four channels that workflow does cover and says plainly that the AUR needs the release job re-run or a manual push.
 - Fixed the release PR workflow failing when re-run for a version whose pull request already exists. It now updates the existing pull request in place — same number, same URL, refreshed notes — rather than aborting on `gh pr create`.
 - Fixed development API writes failing with `Forbidden: cross-origin requests are not accepted` when the interface was opened through a LAN address or a trusted same-origin reverse proxy such as Tailscale Serve. Vite now translates the browser-visible origin only when the browser vouches that the request is same-origin and that origin exactly matches the incoming frontend host. Requests from unrelated pages keep their original origin and remain blocked by the backend guard; the production daemon and its loopback-only boundary are unchanged.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "looptroop",
-  "version": "0.5.5",
+  "version": "0.5.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "looptroop",
-      "version": "0.5.5",
+      "version": "0.5.6",
       "license": "MIT",
       "dependencies": {
         "@hono/node-server": "^2.0.12",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "looptroop",
-  "version": "0.5.5",
+  "version": "0.5.6",
   "description": "Local AI coding orchestration for repo-scale work: LLM-council planning, Ralph-loop recovery, isolated OpenCode worktrees, and human-gated PR delivery.",
   "type": "module",
   "keywords": [


### PR DESCRIPTION
Cuts **0.5.6** from everything merged since 0.5.5.

Merging this starts the release workflow: it builds the binaries, verifies them on all three platforms, drafts the GitHub release, then publishes to npm, the container registries and every package channel. **It runs unattended — there is no approval prompt.** Merging this PR is the approval.

## What ships

- **`looptroop open` is the first thing suggested after installing**, not `setup`; `open` leads the command list
- **Per-command `--help`** for all nine commands
- **Update notices** on `--version`, `status`, `start`, `open` — on stderr, so stdout stays parseable — plus About and a header indicator in the UI
- **`doctor`**: npm added, each tool shown against its newest published version, `✗` for missing versus `!` for degraded, install method with the upgrade command below it, clearer schema and last-start lines
- **`status`/`doctor` no longer say "not running"** to someone looking at the interface served by `npm run dev`
- **yarn and paru** as install channels
- **Attestation** extended to the tarball, bundle, both installer scripts, manifest and checksums
- **Workflow linting** with actionlint + ShellCheck
- **`-bundle.zip` removed** — nothing consumed it

## Note on the changelog

The CLI entries from #51 were missing and were added here before the notes were generated. Without that, the most user-visible work in this release would have shipped undescribed. `.github/releases/0.5.6.md` is regenerated from the changelog so the two cannot disagree.

## After the tag

`USAGE` changed, so `docs/cli.md` on the website is pinned to v0.5.5 and drifts until `CLI_SOURCE_REF` is repointed at `v0.5.6` and `npm run sync:cli` is run. That has to happen after the tag exists.

## Checks

lint 0 · typecheck 0 · **3352 tests** · `verify:version` 0 · `installers:check` 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)