### PR TITLE
fix(ci): refresh the Arch package database before installing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -905,7 +905,22 @@ jobs:
       - name: Install the Arch toolchain
         run: |
           set -eu
-          pacman -Syu --noconfirm --needed base-devel namcap nodejs npm git github-cli sudo
+          # `-Syyu`, with the second `y` forcing a full database refresh.
+          #
+          # The `archlinux:latest` image ships a package database from whenever it
+          # was built, and Arch is a rolling release: by the time this runs, some
+          # of the versions that database names have been superseded and *deleted*
+          # from the mirrors. A plain `-Syu` considers a recent database current,
+          # keeps it, and then asks the CDN for a file that no longer exists —
+          # which fails as a 404 on every mirror, a minute into the job:
+          #
+          #   error: failed retrieving file 'elfutils-0.195-8-x86_64.pkg.tar.zst'
+          #     from fastly.mirror.pkgbuild.com : The requested URL returned error: 404
+          #
+          # This is not flakiness and a re-run is not the fix; it only passes when
+          # the image happens to be fresh. Forcing the refresh asks for versions
+          # the mirrors actually hold.
+          pacman -Syyu --noconfirm --needed base-devel namcap nodejs npm git github-cli sudo
           node --version
 
       # makepkg refuses to run as root, which is the whole reason this exists.


### PR DESCRIPTION
The AUR job fails at `pacman -Syu` with a 404 on **every** mirror:

```
error: failed retrieving file 'elfutils-0.195-8-x86_64.pkg.tar.zst'
  from fastly.mirror.pkgbuild.com : The requested URL returned error: 404
  from geo.mirror.pkgbuild.com    : The requested URL returned error: 404
error: failed to commit transaction (failed to retrieve some files)
```

## Cause

The `archlinux:latest` image carries a package database from whenever it was built. Arch is a rolling release, so versions that database names get superseded and **deleted** from the mirrors. `-Syu` treats a recent-looking database as current and keeps it, then asks the CDN for a package that is no longer there.

`-Syyu` forces the refresh, so the versions requested are the ones the mirrors actually hold.

## This is a fix, not a retry

The job failed on two separate PRs and passed on a re-run in between, which looks like flakiness. It isn't: it passes whenever the image happens to be fresher than the repository has moved, and fails otherwise. Re-running waits for a luckier draw.

Nothing here is a race in our own code — which is the thing the no-retries rule exists to stop anyone hiding.

## Checks

actionlint (with ShellCheck) 0 · `verify:version` 0

Blocking the 0.5.6 release (#52), which will be rebased onto this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)