### PR TITLE
docs(cli): list --print-url where every other flag is listed

### DIFF
--- a/server/cli/cli.ts
+++ b/server/cli/cli.ts
@@ -29,6 +29,7 @@ Commands:
 Options:
   --port <n>     Port to listen on (start, restart)
   --foreground   Run in this terminal instead of the background (start)
+  --print-url    Print the sign-in link instead of opening a browser (open)
   --opencode-logs=all
                  Include managed OpenCode DEBUG output (open, start)
   --json         Machine-readable output (status, doctor)


### PR DESCRIPTION
`--print-url` shipped in 0.5.7 documented only in `looptroop open --help`.

The `USAGE` block is where every other flag appears — including `--opencode-logs=all` from the same release — so `looptroop --help` did not mention it, and neither does the [published CLI reference](https://www.looptroop.ovh/docs/cli), which is generated from that block at the release tag.

That makes the flag discoverable only by someone who already suspects it exists, which is backwards: it is the answer for a machine where no browser opened, and the signed-out screen names it to people who are, by definition, unable to reach the interface.

Caught while running the release checklist's website sync, which regenerates the CLI page from `USAGE` at `v0.5.7` and produced a page without the flag on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)