### PR TITLE
Say when the server could not be reached, instead of loading forever

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ Unreleased changes appear first and represent commits that have not yet been inc
 
 > Changes merged since the last versioned release that have not yet shipped in a tagged version.
 
+### Summary
+- The board and the ticket view now say when they could not reach the server, instead of showing "loading…" forever — an unreachable backend no longer looks like a slow one, or like your tickets were deleted.
+
+### Fixed
+- Fixed the Kanban board and the ticket dashboard presenting a failed request as an ongoing one. Both read only the query's loading flag and had no error branch at all, so a backend that was not answering rendered the "LoopTroop is fetching the tickets" banner indefinitely — and, because `refetchOnWindowFocus` is enabled, re-entered it on every window focus. An empty board with no explanation reads as data loss, so the new banner states that the request failed, says the tickets are still on disk, quotes the reason, and offers a retry.
+- Fixed request failures being reported without their cause. Every fetch threw the same sentence regardless of what happened, so a missing API token, a stopped daemon and a deleted ticket were indistinguishable without opening devtools. Ticket, ticket-list and project fetches now carry the HTTP status and the server's own error message — for example `Failed to fetch tickets (HTTP 503: API token not configured)` — and that line is shown in the new banner.
+
 ## 0.5.7 (2026-08-20)
 
 

--- a/src/components/kanban/KanbanBoard.tsx
+++ b/src/components/kanban/KanbanBoard.tsx
@@ -10,6 +10,7 @@ import { Badge } from '@/components/ui/badge'
 import { RefreshCw, X, ChevronDown, FolderOpen } from 'lucide-react'
 import { Tooltip, TooltipTrigger, TooltipContent } from "@/components/ui/tooltip";
 import { Button } from '@/components/ui/button'
+import { DataUnavailableBanner } from '@/components/shared/DataUnavailableBanner'
 import { ticketMatchesDashboardSearch } from './kanbanSearch'
 import { cn } from '@/lib/utils'
 import {
@@ -132,7 +133,14 @@ function ProjectIcon({
 
 export function KanbanBoard() {
   const { state, dispatch } = useUI()
-  const { data: tickets, isLoading: isLoadingTickets } = useTickets()
+  const {
+    data: tickets,
+    isLoading: isLoadingTickets,
+    isError: isTicketsError,
+    error: ticketsError,
+    refetch: refetchTickets,
+    isFetching: isFetchingTickets,
+  } = useTickets()
   const { data: projects = [] } = useProjects()
 
   const selectedProjectId = state.filters?.projectId ?? null
@@ -674,7 +682,16 @@ export function KanbanBoard() {
         )}
       </div>
 
-      {isLoadingTickets && (
+      {isTicketsError && (
+        <DataUnavailableBanner
+          title="Tickets unavailable"
+          description="LoopTroop could not reach the server, so the board is empty. Your tickets are not lost — check that the LoopTroop backend is running, then retry."
+          error={ticketsError}
+          onRetry={() => { void refetchTickets() }}
+          isRetrying={isFetchingTickets}
+        />
+      )}
+      {isLoadingTickets && !isTicketsError && (
         <div
           className="border-b border-amber-200 bg-amber-50/90 px-4 py-2 dark:border-amber-900/60 dark:bg-amber-950/40 shrink-0"
           role="status"

--- a/src/components/kanban/__tests__/KanbanBoard.test.tsx
+++ b/src/components/kanban/__tests__/KanbanBoard.test.tsx
@@ -114,6 +114,76 @@ describe('KanbanBoard', () => {
     vi.useRealTimers()
   })
 
+  /**
+   * A backend that is not answering used to render as the "fetching the
+   * tickets" banner, forever and without a single mention of failure, so an
+   * unreachable daemon was indistinguishable from a slow one.
+   */
+  describe('when the tickets query fails', () => {
+    const failure = new Error('Failed to fetch tickets (HTTP 503: API token not configured)')
+
+    function mockFailedTickets(overrides: Record<string, unknown> = {}) {
+      mockUseTickets.mockReturnValue({
+        data: undefined,
+        isLoading: false,
+        isError: true,
+        error: failure,
+        refetch: vi.fn(),
+        isFetching: false,
+        ...overrides,
+      })
+      mockUseProjects.mockReturnValue({ data: [] })
+    }
+
+    it('says the tickets could not be loaded instead of claiming to load them', () => {
+      mockFailedTickets()
+      renderWithProviders(<KanbanBoard />)
+
+      expect(screen.getByRole('alert')).toHaveTextContent('Tickets unavailable')
+      expect(screen.queryByText(/LoopTroop is fetching the tickets/)).not.toBeInTheDocument()
+    })
+
+    it('quotes the reason, so the status code is visible without devtools', () => {
+      mockFailedTickets()
+      renderWithProviders(<KanbanBoard />)
+
+      expect(screen.getByRole('alert')).toHaveTextContent('HTTP 503: API token not configured')
+    })
+
+    it('reassures that nothing was deleted, because an empty board reads as data loss', () => {
+      mockFailedTickets()
+      renderWithProviders(<KanbanBoard />)
+
+      expect(screen.getByRole('alert')).toHaveTextContent('Your tickets are not lost')
+    })
+
+    it('refetches when the retry button is used', () => {
+      const refetch = vi.fn()
+      mockFailedTickets({ refetch })
+      renderWithProviders(<KanbanBoard />)
+
+      fireEvent.click(screen.getByRole('button', { name: /retry/i }))
+
+      expect(refetch).toHaveBeenCalledTimes(1)
+    })
+
+    it('disables the retry button while a retry is already in flight', () => {
+      mockFailedTickets({ isFetching: true })
+      renderWithProviders(<KanbanBoard />)
+
+      expect(screen.getByRole('button', { name: /retrying/i })).toBeDisabled()
+    })
+
+    it('still shows the loading banner for a genuinely pending first load', () => {
+      mockUseTickets.mockReturnValue({ data: undefined, isLoading: true, isError: false })
+      mockUseProjects.mockReturnValue({ data: [] })
+      renderWithProviders(<KanbanBoard />)
+
+      expect(screen.getByText(/LoopTroop is fetching the tickets/)).toBeInTheDocument()
+      expect(screen.queryByRole('alert')).not.toBeInTheDocument()
+    })
+  })
+
   it('renders 4 columns', () => {
     const { container } = renderWithProviders(<KanbanBoard />)
     const todo = screen.getByText('To Do')

--- a/src/components/shared/DataUnavailableBanner.tsx
+++ b/src/components/shared/DataUnavailableBanner.tsx
@@ -1,0 +1,79 @@
+import { AlertTriangle, RefreshCw } from 'lucide-react'
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import { Tooltip, TooltipTrigger, TooltipContent } from '@/components/ui/tooltip'
+import { describeQueryError } from '@/lib/fetchError'
+
+interface DataUnavailableBannerProps {
+  /** What could not be loaded, e.g. "Tickets unavailable". */
+  title: string
+  /** What the reader should do about it. */
+  description: string
+  /** Whatever the query rejected with; rendered verbatim when it says something. */
+  error?: unknown
+  onRetry?: () => void
+  isRetrying?: boolean
+}
+
+/**
+ * The counterpart to the "loading…" banner, for a query that has actually
+ * failed.
+ *
+ * A board that shows "fetching the tickets" forever is indistinguishable from a
+ * backend that is not answering, which is exactly how a dead daemon reads as a
+ * slow one. This states that the request failed, quotes the reason, and offers
+ * the retry — so the next person spends their time on the daemon rather than on
+ * their network.
+ */
+export function DataUnavailableBanner({
+  title,
+  description,
+  error,
+  onRetry,
+  isRetrying = false,
+}: DataUnavailableBannerProps) {
+  const detail = describeQueryError(error)
+
+  return (
+    <div
+      className="border-b border-red-200 bg-red-50/90 px-4 py-2 dark:border-red-900/60 dark:bg-red-950/40 shrink-0"
+      role="alert"
+      aria-live="assertive"
+    >
+      <div className="flex flex-col gap-1">
+        <div className="flex items-center gap-2">
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Badge
+                variant="outline"
+                className="w-fit gap-1.5 border-red-300 bg-red-100/80 text-[11px] text-red-900 dark:border-red-800 dark:bg-red-900/40 dark:text-red-200"
+              >
+                <AlertTriangle className="h-3 w-3" />
+                {title}
+              </Badge>
+            </TooltipTrigger>
+            <TooltipContent className="max-w-xs text-center text-balance">
+              The server did not answer this request. It is most likely not running.
+            </TooltipContent>
+          </Tooltip>
+          {onRetry && (
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={onRetry}
+              disabled={isRetrying}
+              className="h-6 gap-1.5 border-red-300 bg-red-100/60 px-2 text-[11px] text-red-900 hover:bg-red-100 dark:border-red-800 dark:bg-red-900/30 dark:text-red-200"
+            >
+              <RefreshCw className={`h-3 w-3 ${isRetrying ? 'animate-spin' : ''}`} />
+              {isRetrying ? 'Retrying…' : 'Retry'}
+            </Button>
+          )}
+        </div>
+        <p className="text-xs leading-5 text-red-900/75 dark:text-red-200/80">{description}</p>
+        {detail && (
+          <p className="font-mono text-[11px] leading-5 text-red-900/60 dark:text-red-200/60">{detail}</p>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/src/components/ticket/TicketDashboard.tsx
+++ b/src/components/ticket/TicketDashboard.tsx
@@ -22,6 +22,8 @@ import { BEADS_APPROVAL_FOCUS_EVENT } from '@/lib/beadsDocument'
 import { WORKSPACE_PHASE_NAVIGATE_EVENT, type WorkspacePhaseNavigateDetail } from '@/lib/workspaceNavigation'
 import { normalizeTicketForRender } from '@/lib/ticketNormalization'
 import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import { DataUnavailableBanner } from '@/components/shared/DataUnavailableBanner'
 import { Tooltip, TooltipTrigger, TooltipContent } from "@/components/ui/tooltip";
 import { useRecoveryAutoReload } from '@/hooks/useRecoveryAutoReload'
 
@@ -180,7 +182,13 @@ function SSELogConnector({
 export function TicketDashboard() {
   const { state, dispatch } = useUI()
   const ticketId = state.selectedTicketId
-  const { data: ticket } = useTicket(ticketId)
+  const {
+    data: ticket,
+    isError: isTicketError,
+    error: ticketError,
+    refetch: refetchTicket,
+    isFetching: isFetchingTicket,
+  } = useTicket(ticketId)
   const { mutate: saveTicketUiState } = useSaveTicketUIState()
   const renderedTicketIdsRef = useRef(new Set<string>())
   const [navWidth, setNavWidth] = useState(280)
@@ -502,6 +510,31 @@ export function TicketDashboard() {
   }, [dispatch, isMobileNavOpen])
 
   if (!ticketId) return null
+
+  // Checked before the skeleton: a failed fetch also leaves `ticket` undefined,
+  // and rendering the "loading…" skeleton for it is what makes a dead backend
+  // look like a slow one.
+  if (!ticket && isTicketError) return (
+    <div className="fixed inset-0 z-[60] bg-background flex flex-col">
+      <div className="h-12 border-b border-border flex items-center px-4 gap-3">
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={() => dispatch({ type: 'CLOSE_TICKET' })}
+          className="h-8 text-xs"
+        >
+          Back to board
+        </Button>
+      </div>
+      <DataUnavailableBanner
+        title="Ticket unavailable"
+        description="LoopTroop could not load this ticket from the server. Check that the LoopTroop backend is running, then retry."
+        error={ticketError}
+        onRetry={() => { void refetchTicket() }}
+        isRetrying={isFetchingTicket}
+      />
+    </div>
+  )
 
   if (!ticket) return (
     <div className="fixed inset-0 z-[60] bg-background flex flex-col">

--- a/src/components/ticket/__tests__/TicketDashboard.test.tsx
+++ b/src/components/ticket/__tests__/TicketDashboard.test.tsx
@@ -18,7 +18,13 @@ const mockSSEState = vi.hoisted(() => ({
   connectionState: 'connected' as 'connecting' | 'connected' | 'reconnecting',
 }))
 const mockTicketQuery = vi.hoisted(() => ({
-  override: null as null | { data: Ticket | undefined },
+  override: null as null | {
+    data: Ticket | undefined
+    isError?: boolean
+    error?: unknown
+    refetch?: () => void
+    isFetching?: boolean
+  },
 }))
 const useRecoveryAutoReloadMock = vi.hoisted(() => vi.fn())
 const saveUiStateMutate = vi.hoisted(() => vi.fn())
@@ -422,6 +428,32 @@ describe('TicketDashboard', () => {
     await waitFor(() => {
       expect(useRecoveryAutoReloadMock).toHaveBeenCalledWith(`ticket-loading:${selectedTicketId}`, true)
     })
+  })
+
+  /**
+   * A failed fetch leaves `ticket` undefined, which is the same state as a
+   * pending one. Showing the skeleton for both is what made an unreachable
+   * backend read as "still loading".
+   */
+  it('reports a failed ticket fetch instead of showing the loading skeleton', async () => {
+    const refetch = vi.fn()
+    mockTicketQuery.override = {
+      data: undefined,
+      isError: true,
+      error: new Error('Failed to fetch ticket (HTTP 503: API token not configured)'),
+      refetch,
+      isFetching: false,
+    }
+
+    renderDashboard()
+
+    const alert = await screen.findByRole('alert')
+    expect(alert).toHaveTextContent('Ticket unavailable')
+    expect(alert).toHaveTextContent('HTTP 503: API token not configured')
+    expect(screen.queryByText('Loading ticket...')).not.toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: /retry/i }))
+    expect(refetch).toHaveBeenCalledTimes(1)
   })
 
   it('renders SSE log events in the active ticket without reopening it', async () => {

--- a/src/hooks/useProjects.ts
+++ b/src/hooks/useProjects.ts
@@ -4,6 +4,7 @@ import { clearErrorTicketSeen } from '@/lib/errorTicketSeen'
 import { getTicketArtifactsQueryKey } from './useTicketArtifacts'
 import type { GitHookPolicy } from '@/lib/executionSetupPlan'
 import { normalizeGitHookPolicySetting } from '@/lib/gitHookPolicySetting'
+import { failedResponseError } from '@/lib/fetchError'
 import { DEFAULT_IGNORE_MODE, normalizeIgnoreMode, type IgnoreMode } from '@/lib/ignoreMode'
 
 interface Project {
@@ -105,7 +106,7 @@ function removeDeletedProjectTicketCaches(
 
 async function fetchProjects(): Promise<Project[]> {
   const res = await fetch('/api/projects')
-  if (!res.ok) throw new Error('Failed to fetch projects')
+  if (!res.ok) throw await failedResponseError(res, 'Failed to fetch projects')
   const projects = await res.json() as Project[]
   return projects.map((project) => ({
     ...project,

--- a/src/hooks/useTickets.ts
+++ b/src/hooks/useTickets.ts
@@ -5,6 +5,7 @@ import { mergeTicketInCache, patchTicketStatusInCache } from './ticketStatusCach
 import type { WorkflowAction } from '@shared/workflowMeta'
 import type { InterviewSessionSnapshot, InterviewSessionView, PersistedInterviewBatch } from '@shared/interviewSession'
 import { clearErrorTicketSeen } from '@/lib/errorTicketSeen'
+import { failedResponseError } from '@/lib/fetchError'
 import type { TicketErrorOccurrence } from '@/lib/errorOccurrences'
 import {
   createTicketUiStateActionId,
@@ -255,13 +256,13 @@ export function getTicketsAutoRefreshInterval(
 async function fetchTickets(projectId?: number): Promise<Ticket[]> {
   const url = projectId ? `/api/tickets?projectId=${projectId}` : '/api/tickets'
   const res = await fetch(url)
-  if (!res.ok) throw new Error('Failed to fetch tickets')
+  if (!res.ok) throw await failedResponseError(res, 'Failed to fetch tickets')
   return res.json()
 }
 
 async function fetchTicket(id: string): Promise<Ticket> {
   const res = await fetch(`/api/tickets/${id}`)
-  if (!res.ok) throw new Error('Failed to fetch ticket')
+  if (!res.ok) throw await failedResponseError(res, 'Failed to fetch ticket')
   return res.json()
 }
 

--- a/src/lib/__tests__/fetchError.test.ts
+++ b/src/lib/__tests__/fetchError.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect } from 'vitest'
+import { describeQueryError, failedResponseError } from '../fetchError'
+
+function jsonResponse(status: number, body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  })
+}
+
+describe('failedResponseError', () => {
+  it('quotes the status and the server\'s own error, the pair that names the cause', async () => {
+    const error = await failedResponseError(
+      jsonResponse(503, { error: 'API token not configured' }),
+      'Failed to fetch tickets',
+    )
+
+    expect(error.message).toBe('Failed to fetch tickets (HTTP 503: API token not configured)')
+  })
+
+  it('still reports the status when the body carries no error field', async () => {
+    const error = await failedResponseError(jsonResponse(500, { unrelated: true }), 'Failed to fetch tickets')
+
+    // The body is not dropped: an unrecognised shape is still better than
+    // nothing, but the status is what must always survive.
+    expect(error.message).toContain('HTTP 500')
+  })
+
+  it('reports the status alone for an empty body', async () => {
+    const error = await failedResponseError(new Response('', { status: 502 }), 'Failed to fetch projects')
+
+    expect(error.message).toBe('Failed to fetch projects (HTTP 502)')
+  })
+
+  it('quotes a plain-text body, which is what a proxy returns', async () => {
+    const error = await failedResponseError(new Response('Bad Gateway', { status: 502 }), 'Failed to fetch tickets')
+
+    expect(error.message).toBe('Failed to fetch tickets (HTTP 502: Bad Gateway)')
+  })
+
+  it('caps a long body so an HTML error page cannot fill the banner', async () => {
+    const error = await failedResponseError(new Response('x'.repeat(5000), { status: 500 }), 'Failed to fetch tickets')
+
+    expect(error.message.length).toBeLessThan(300)
+    expect(error.message).toContain('…')
+  })
+
+  it('never throws while describing a failure, even on an unreadable body', async () => {
+    // A response whose body already errored is exactly what an aborted request
+    // leaves behind; describing the failure must not replace it with a new one.
+    const unreadable = {
+      status: 500,
+      text: () => Promise.reject(new Error('body already consumed')),
+    } as unknown as Response
+
+    const error = await failedResponseError(unreadable, 'Failed to fetch tickets')
+
+    expect(error.message).toBe('Failed to fetch tickets (HTTP 500)')
+  })
+})
+
+describe('describeQueryError', () => {
+  it('reads the message off an Error', () => {
+    expect(describeQueryError(new Error('Failed to fetch tickets (HTTP 503)')))
+      .toBe('Failed to fetch tickets (HTTP 503)')
+  })
+
+  it('accepts a bare string, which a rejected promise may carry instead', () => {
+    expect(describeQueryError('boom')).toBe('boom')
+  })
+
+  it('reports nothing for a blank or unrecognised rejection', () => {
+    // The banner drops the detail line entirely rather than printing an empty
+    // one or "[object Object]".
+    expect(describeQueryError(new Error('   '))).toBeNull()
+    expect(describeQueryError('')).toBeNull()
+    expect(describeQueryError(undefined)).toBeNull()
+    expect(describeQueryError({ status: 503 })).toBeNull()
+  })
+})

--- a/src/lib/fetchError.ts
+++ b/src/lib/fetchError.ts
@@ -1,0 +1,54 @@
+/**
+ * Turns a failed `Response` into an error that says what actually went wrong.
+ *
+ * A bare "Failed to fetch tickets" is the same sentence whether the daemon is
+ * down, the token is missing or the ticket is gone, so the status code and the
+ * server's own `{ error }` body are folded into the message. That is the
+ * difference between "the UI is slow" and "HTTP 503: API token not configured".
+ */
+export async function failedResponseError(res: Response, summary: string): Promise<Error> {
+  const detail = await readErrorDetail(res)
+  return new Error(detail ? `${summary} (HTTP ${res.status}: ${detail})` : `${summary} (HTTP ${res.status})`)
+}
+
+/**
+ * Reads whatever a failed query threw and returns a line worth showing.
+ *
+ * The fetchers throw `Error`, but a query can also reject with a string or a
+ * `TypeError` from `fetch` itself when the connection is refused, so anything
+ * that is not an `Error` is stringified rather than dropped.
+ */
+export function describeQueryError(error: unknown): string | null {
+  if (error instanceof Error) return error.message.trim() || null
+  if (typeof error === 'string') return error.trim() || null
+  return null
+}
+
+/**
+ * Body of an error response, when it carries one worth quoting.
+ *
+ * The body is read defensively: an aborted or already-consumed response throws
+ * here, and a failure to describe an error must never replace it.
+ */
+async function readErrorDetail(res: Response): Promise<string | null> {
+  try {
+    const text = (await res.text()).trim()
+    if (!text) return null
+
+    try {
+      const parsed = JSON.parse(text) as unknown
+      if (parsed && typeof parsed === 'object' && 'error' in parsed) {
+        const { error } = parsed as { error: unknown }
+        if (typeof error === 'string' && error.trim()) return error.trim()
+      }
+    } catch {
+      // Not JSON. The raw text is still the best available answer.
+    }
+
+    // An HTML error page from a proxy is noise, so it is capped rather than
+    // pasted into the banner whole.
+    return text.length > 200 ? `${text.slice(0, 200)}…` : text
+  } catch {
+    return null
+  }
+}


### PR DESCRIPTION
## What this fixes

The Kanban board and the ticket dashboard read only their query's loading flag. Neither had an error branch anywhere, so a backend that was not answering rendered *"LoopTroop is fetching the tickets"* indefinitely — and because `refetchOnWindowFocus` is enabled, re-entered that banner on every window focus.

This was found the hard way. A dev daemon exited on a schema guard while its `npm run dev` wrapper stayed up, so systemd's `Restart=always` never fired. Every `/api` call returned **503 in four milliseconds** and the UI reported it as an ongoing fetch for hours. An empty board with no explanation reads as *deleted data* — which is the worst available reading of a backend that is merely down.

## What changed

- **`DataUnavailableBanner`** — a shared alert, visually distinct from the amber "still working" banner and carrying `role="alert"` so assistive technology is told as well. It states the failure, says the tickets are still on disk, quotes the reason, and offers a retry.
- **`KanbanBoard` / `TicketDashboard`** render it on `isError`. The loading banner is explicitly suppressed while an error shows, so the two can never appear together. `TicketDashboard` checks the error *before* its skeleton, because a failed fetch leaves `ticket` undefined exactly as a pending one does — the ambiguity that caused this.
- **`failedResponseError`** folds the HTTP status and the server's own `{ error }` body into the thrown message, so the banner can say `HTTP 503: API token not configured` rather than `Failed to fetch tickets`. Every fetcher previously threw one fixed sentence, which is why a missing token, a stopped daemon and a deleted ticket were indistinguishable without devtools. Applied to the ticket, ticket-list and project fetches.

The error body is read defensively and capped at 200 characters: an aborted response throws on `.text()`, and a proxy's HTML error page would otherwise land in the banner whole. Describing a failure must never raise a second one.

## Impact

No API, schema or workflow change — failure rendering only. Mutation paths are untouched, as they already surface their errors. `describeQueryError` lives in `lib/fetchError` rather than beside the component so the component file exports only a component, which `react-refresh` requires.

## Verification

- `npm run test:client` — 83 files, 861 tests passing (before the new ones)
- `npm run lint` — clean, no warnings
- `npx tsc -b` — clean
- `npm run verify:version` — pass

New coverage: six `KanbanBoard` cases (error replaces the loading banner, the reason is quoted, the reassurance is present, retry refetches, retry is disabled mid-flight, and a genuinely pending load still shows the loading banner), one `TicketDashboard` case, and ten unit tests for the error-description helpers including the unreadable-body path.

No end-to-end testing performed, per the project's testing policy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)