### PR TITLE
Serve the built bundle when the dev server is the wrong tool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,10 +11,15 @@ Unreleased changes appear first and represent commits that have not yet been inc
 
 ### Summary
 - The board and the ticket view now say when they could not reach the server, instead of showing "loading…" forever — an unreachable backend no longer looks like a slow one, or like your tickets were deleted.
+- The dev stack can serve the built frontend bundle instead of the dev server, which makes running LoopTroop over a tunnel or a remote link dramatically faster.
+
+### Added
+- Added `LOOPTROOP_DEV_FRONTEND=preview`, which makes `npm run dev` build the dashboard once and serve the bundle rather than starting the frontend dev server. The dev server sends every source file as its own request — over 300 source modules before dependencies — and over a tunnel each one pays the round trip; the built bundle is a few dozen assets. Hot reload is the trade, so code changes need a restart. Everything else is unchanged: same port, same backend, same proxy. An unrecognised value warns and falls back to the dev server rather than silently serving the slow path to someone who asked for the fast one.
 
 ### Fixed
 - Fixed the Kanban board and the ticket dashboard presenting a failed request as an ongoing one. Both read only the query's loading flag and had no error branch at all, so a backend that was not answering rendered the "LoopTroop is fetching the tickets" banner indefinitely — and, because `refetchOnWindowFocus` is enabled, re-entered it on every window focus. An empty board with no explanation reads as data loss, so the new banner states that the request failed, says the tickets are still on disk, quotes the reason, and offers a retry.
 - Fixed request failures being reported without their cause. Every fetch threw the same sentence regardless of what happened, so a missing API token, a stopped daemon and a deleted ticket were indistinguishable without opening devtools. Ticket, ticket-list and project fetches now carry the HTTP status and the server's own error message — for example `Failed to fetch tickets (HTTP 503: API token not configured)` — and that line is shown in the new banner.
+- Fixed `npm run preview` serving a dashboard that could not load any data. The script has always existed, but no `preview` configuration did, so the built bundle was served with no `/api` proxy behind it — and that proxy is not merely routing: it attaches the API token and rewrites the Host and Origin headers the daemon's loopback guard requires. Preview now shares one proxy definition with the dev server, so the two cannot drift apart into a blanket `403` with nothing to point at.
 
 ## 0.5.7 (2026-08-20)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,6 +28,18 @@ npm run dev
 
 Open `http://localhost:5173` after the dev server starts.
 
+Running the stack over a tunnel or a remote link? The dev server sends every
+source file as a separate request, and each one pays the round trip. Serve the
+built bundle instead:
+
+```bash
+LOOPTROOP_DEV_FRONTEND=preview npm run dev
+```
+
+Same URL, same backend, same ports — but the frontend is built once and served
+as a bundle. Hot reload is the trade: code changes need a restart. Use it when
+you are running LoopTroop rather than developing it; leave it unset otherwise.
+
 Useful commands:
 
 ```bash

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "opencode:upgrade": "tsx scripts/dev-opencode-upgrade.ts",
     "dev:opencode": "tsx scripts/dev-opencode.ts",
     "dev:frontend": "vite",
+    "dev:frontend:preview": "vite build && vite preview",
     "dev:backend": "tsx scripts/dev-backend.ts",
     "diagnose:stall": "tsx scripts/diagnose-runtime-stall.ts",
     "verify:no-native-addons": "node scripts/verify-no-native-addons.mjs",

--- a/scripts/dev-frontend-mode.ts
+++ b/scripts/dev-frontend-mode.ts
@@ -1,0 +1,42 @@
+export const LOOPTROOP_DEV_FRONTEND = 'LOOPTROOP_DEV_FRONTEND'
+
+export type DevFrontendMode = 'dev' | 'preview'
+
+type Env = Partial<Record<string, string | undefined>>
+
+const PREVIEW_VALUES = new Set(['preview', 'built', 'build'])
+const DEV_VALUES = new Set(['', 'dev', 'hmr', 'default'])
+
+/**
+ * Chooses between the frontend dev server and the built bundle.
+ *
+ * `dev` (the default) serves every source file separately and hot-reloads
+ * edits. That is the right trade on the machine doing the editing, and the
+ * wrong one everywhere else: over a tunnel or a remote link, each of those
+ * hundreds of files pays the round trip, and a stack nobody is editing pays it
+ * for a feature nobody is using.
+ *
+ * `preview` builds once and serves the bundle instead. No hot reload, so a code
+ * change needs a restart — which is the deal worth taking when the stack is
+ * being *run* rather than developed.
+ */
+export function resolveDevFrontendMode(env: Env = process.env): DevFrontendMode {
+  const raw = env[LOOPTROOP_DEV_FRONTEND]?.trim().toLowerCase() ?? ''
+
+  if (PREVIEW_VALUES.has(raw)) return 'preview'
+  if (DEV_VALUES.has(raw)) return 'dev'
+
+  // An unrecognised value is a typo, and silently serving the dev bundle to
+  // someone who asked for the built one hides exactly the slowness they were
+  // trying to remove. Say so, then fall back to the safe default.
+  console.warn(
+    `[dev] Ignoring ${LOOPTROOP_DEV_FRONTEND}="${raw}": expected "dev" or "preview". Using the dev server.`,
+  )
+  return 'dev'
+}
+
+export function describeDevFrontendMode(mode: DevFrontendMode): string {
+  return mode === 'preview'
+    ? 'Built bundle (no hot reload) — faster first load, rebuild to see code changes'
+    : 'Dev server with hot reload'
+}

--- a/scripts/dev.ts
+++ b/scripts/dev.ts
@@ -19,6 +19,7 @@ import {
   type DependencySyncReport,
 } from './dev-maintenance'
 import { getDevLanUrls, LOOPTROOP_DEV_HOST, resolveDevHostMode } from './dev-host-mode'
+import { describeDevFrontendMode, resolveDevFrontendMode } from './dev-frontend-mode'
 import { resolveOpenCodeBaseUrl } from './opencode-dev-base-url'
 import { LOOPTROOP_OPENCODE_LOGS, resolveOpenCodeLogMode } from './opencode-log-mode'
 import { getWslLanAccessPlan } from './wsl-lan-access'
@@ -90,6 +91,8 @@ if (opencodeLogMode.mode === 'all') {
 if (devHostMode.enabled) {
   childEnv[LOOPTROOP_DEV_HOST] = devHostMode.bindHost
 }
+
+const frontendMode = resolveDevFrontendMode(process.env)
 
 const { baseUrl, note, status } = await resolveOpenCodeBaseUrl({
   requestedBaseUrl,
@@ -292,13 +295,21 @@ const services: DevService[] = [
     displayCommand: 'tsx scripts/dev-opencode.ts',
     description: 'Ensure the local OpenCode server is reachable, then start it if needed.',
   },
-  {
-    name: 'WEB',
-    prefixColor: 'bgBlue.black',
-    command: 'npm:dev:frontend',
-    displayCommand: 'vite',
-    description: 'Start the frontend dev server for the LoopTroop dashboard.',
-  },
+  frontendMode === 'preview'
+    ? {
+      name: 'WEB',
+      prefixColor: 'bgBlue.black',
+      command: 'npm:dev:frontend:preview',
+      displayCommand: 'vite build && vite preview',
+      description: 'Build the dashboard, then serve the built bundle. No hot reload.',
+    }
+    : {
+      name: 'WEB',
+      prefixColor: 'bgBlue.black',
+      command: 'npm:dev:frontend',
+      displayCommand: 'vite',
+      description: 'Start the frontend dev server for the LoopTroop dashboard.',
+    },
   {
     name: 'API',
     prefixColor: 'bgGreen.black',
@@ -315,6 +326,7 @@ printSummaryLine('Documentation', `${docsOrigin}/docs/ (external)`)
 printSummaryLine('OpenCode', baseUrl)
 printSummaryLine('LAN sharing', formatLanSharingSummary())
 await printLanSharingDetails()
+printSummaryLine('Frontend', describeDevFrontendMode(frontendMode))
 printSummaryLine('OpenCode logs', formatOpenCodeLogSummary(status))
 printSummaryBlock('Package gate', formatDependencyReleasePolicySummaryLines())
 

--- a/tests/dev-frontend-mode.test.ts
+++ b/tests/dev-frontend-mode.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import {
+  describeDevFrontendMode,
+  resolveDevFrontendMode,
+  LOOPTROOP_DEV_FRONTEND,
+} from '../scripts/dev-frontend-mode'
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe('resolveDevFrontendMode', () => {
+  it('defaults to the dev server when nothing asked otherwise', () => {
+    expect(resolveDevFrontendMode({})).toBe('dev')
+    expect(resolveDevFrontendMode({ [LOOPTROOP_DEV_FRONTEND]: '' })).toBe('dev')
+  })
+
+  it('accepts the spellings someone would reach for', () => {
+    for (const value of ['preview', 'built', 'build', 'PREVIEW', '  Preview  ']) {
+      expect(resolveDevFrontendMode({ [LOOPTROOP_DEV_FRONTEND]: value }), value).toBe('preview')
+    }
+  })
+
+  it('accepts the explicit dev spellings too', () => {
+    for (const value of ['dev', 'hmr', 'default', 'DEV']) {
+      expect(resolveDevFrontendMode({ [LOOPTROOP_DEV_FRONTEND]: value }), value).toBe('dev')
+    }
+  })
+
+  it('warns and falls back on a typo rather than silently serving the wrong thing', () => {
+    // Someone who typed "preveiw" wanted the built bundle. Quietly handing them
+    // the dev server hides the exact slowness they were trying to remove.
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+
+    expect(resolveDevFrontendMode({ [LOOPTROOP_DEV_FRONTEND]: 'preveiw' })).toBe('dev')
+
+    expect(warn).toHaveBeenCalledTimes(1)
+    expect(warn.mock.calls[0]?.[0]).toContain('preveiw')
+    expect(warn.mock.calls[0]?.[0]).toContain(LOOPTROOP_DEV_FRONTEND)
+  })
+})
+
+describe('describeDevFrontendMode', () => {
+  it('says hot reload is gone, because that is the whole trade', () => {
+    expect(describeDevFrontendMode('preview')).toContain('no hot reload')
+    expect(describeDevFrontendMode('dev')).toContain('hot reload')
+  })
+})

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig } from 'vite'
+import { defineConfig, type ProxyOptions } from 'vite'
 import react from '@vitejs/plugin-react'
 import tailwindcss from '@tailwindcss/vite'
 import { readFileSync } from 'fs'
@@ -20,6 +20,56 @@ const backendOrigin = getBackendOrigin()
 const apiToken = process.env.LOOPTROOP_API_TOKEN?.trim() ?? ''
 const apiTokenHeader = 'X-LoopTroop-Token'
 const devHostMode = resolveDevHostMode()
+
+/**
+ * The `/api` proxy, shared by `vite dev` and `vite preview`.
+ *
+ * It carries three jobs the browser cannot do for itself, and all three are
+ * load-bearing:
+ *
+ * - it attaches the API token, so the page never holds a credential;
+ * - `changeOrigin` rewrites Host to the backend's own authority, without which
+ *   the daemon's loopback guard rejects every request that reached the frontend
+ *   under any other name — a tunnel or a reverse proxy, for instance;
+ * - it overrides Origin for the same guard.
+ *
+ * Defined once because a second copy would drift, and the drift would surface
+ * as a blanket 403 with nothing to point at.
+ */
+const apiProxy: Record<string, ProxyOptions> = {
+  '/api': {
+    target: backendOrigin,
+    changeOrigin: true,
+    configure: (proxy) => {
+      proxy.on('proxyReq', (proxyReq, req) => {
+        if (apiToken) {
+          proxyReq.setHeader(apiTokenHeader, apiToken)
+        }
+
+        const originOverride = getDevProxyOriginOverride({
+          origin: req.headers.origin,
+          host: req.headers.host,
+          secFetchSite: req.headers['sec-fetch-site'],
+          backendOrigin,
+        })
+        if (originOverride) {
+          proxyReq.setHeader('Origin', originOverride)
+        }
+      })
+      proxy.on('error', (err, _req, res) => {
+        if ('code' in err && err.code === 'ECONNREFUSED') {
+          // Backend not ready yet — return 503 silently so the
+          // client-side health poller can retry without noisy logs.
+          if (res && 'writeHead' in res) {
+            (res as ServerResponse).writeHead(503, { 'Content-Type': 'application/json' })
+            ;(res as ServerResponse).end(JSON.stringify({ error: 'Backend not ready' }))
+          }
+          return
+        }
+      })
+    },
+  },
+}
 
 function detectWslRuntime() {
   if (process.platform !== 'linux') return false
@@ -195,39 +245,17 @@ export default defineConfig({
     watch: {
       usePolling: watchPolling.usePolling,
     },
-    proxy: {
-      '/api': {
-        target: backendOrigin,
-        changeOrigin: true,
-        configure: (proxy) => {
-          proxy.on('proxyReq', (proxyReq, req) => {
-            if (apiToken) {
-              proxyReq.setHeader(apiTokenHeader, apiToken)
-            }
-
-            const originOverride = getDevProxyOriginOverride({
-              origin: req.headers.origin,
-              host: req.headers.host,
-              secFetchSite: req.headers['sec-fetch-site'],
-              backendOrigin,
-            })
-            if (originOverride) {
-              proxyReq.setHeader('Origin', originOverride)
-            }
-          })
-          proxy.on('error', (err, _req, res) => {
-            if ('code' in err && err.code === 'ECONNREFUSED') {
-              // Backend not ready yet — return 503 silently so the
-              // client-side health poller can retry without noisy logs.
-              if (res && 'writeHead' in res) {
-                (res as import('http').ServerResponse).writeHead(503, { 'Content-Type': 'application/json' })
-                ;(res as import('http').ServerResponse).end(JSON.stringify({ error: 'Backend not ready' }))
-              }
-              return
-            }
-          })
-        },
-      },
-    },
+    proxy: apiProxy,
+  },
+  // `vite preview` serves the built bundle, and it needs the same proxy for one
+  // reason that is easy to miss: the proxy is not a routing convenience, it is
+  // what authenticates the browser. Without it `preview` serves a working page
+  // whose every request is rejected, which is worse than not running at all.
+  preview: {
+    headers: DEV_SERVER_RESOURCE_HEADERS,
+    host: devHostMode.enabled ? devHostMode.bindHost : undefined,
+    port: getFrontendPort(),
+    strictPort: true,
+    proxy: apiProxy,
   },
 })


### PR DESCRIPTION
## Why

`npm run dev` starts the frontend dev server, which sends **every source file as its own request** — over 300 source modules before dependencies are counted. On the machine doing the editing that is the right trade, and hot reload pays for it. Over a tunnel or a remote link it is the wrong one: each of those requests pays the round trip, and a stack nobody is editing pays it for a feature nobody is using.

`LOOPTROOP_DEV_FRONTEND=preview npm run dev` builds the dashboard once and serves the bundle instead — a few dozen assets. Same port, same backend, same proxy, same readiness detection (`vite preview` also announces `Local:`). Hot reload is the trade, so code changes need a restart.

## It also fixes `npm run preview`, which never worked

The script has existed for a long time. No `preview` configuration ever did — so it served the built bundle with **no `/api` proxy behind it**.

That matters more than routing normally would, because the proxy is what *authenticates the browser*. It attaches the API token, and `changeOrigin` rewrites Host to the backend's own authority. Without that rewrite the daemon's loopback guard rejects everything that arrived under any other name. Verified directly:

```
Host: localhost:3000                    → 200
Host: vps-littlecreek.<tailnet>.ts.net  → 403 "this API answers only on loopback"
```

So `npm run preview` produced a working-*looking* page whose every request failed — worse than not running at all.

## Key decisions

- **One proxy definition**, shared by `server` and `preview`. A second copy would drift, and the drift surfaces as a blanket `403` with nothing to point at.
- **Mode resolution in its own module**, matching `dev-host-mode`, so it is testable without booting the stack.
- **An unrecognised value warns and falls back** to the dev server. Silently serving the slow path to someone who typed `preveiw` hides exactly the slowness they were trying to remove.

## Impact

Opt-in and dev-only. Unset, every path is byte-for-byte what it was. No product code, no API, no schema; the npm script is additive.

## Verification

Verified by running it, not by reading it — the stack boots in preview mode, and `/api/tickets` through the preview server returns **200 with 11 tickets and no credentials from the client**, proving the proxy is still doing the authenticating.

- `npm test` — 293 files, **3392 passed**, 3 skipped
- `npm run lint` — clean
- `npx tsc -b` — clean

5 new tests for the mode resolver, including the typo-fallback path.

No end-to-end testing performed, per the project's testing policy.

> Note: touches `CHANGELOG.md` in the same place as #61, so whichever merges second needs a rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)