### PR TITLE
Fix historical per-bead log retrieval

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Unreleased changes appear first and represent commits that have not yet been inc
 - The dev stack can serve the built frontend bundle instead of the dev server, which makes running LoopTroop over a tunnel or a remote link dramatically faster.
 - A backend that dies during `npm run dev` now takes the dev stack down with it, instead of leaving a frontend serving a dashboard whose every request fails.
 - The folder-ignore policy now looks like every other **Advanced** option: one row, one selector, with each choice explained on hover.
+- Completed bead transcripts now remain available in the per-bead and per-iteration log view after execution advances.
 
 ### Changed
 - Manual QA is now enabled by default. The profile default (`PROFILE_DEFAULTS.manualQaEnabled`) flips to `true`, new database profiles seed the enabled value, and every place that fell back to "disabled" when no explicit choice existed — profile setup, project creation, ticket creation, and the draft ticket view — now falls back to the profile default. Existing profiles, projects, and tickets keep whatever they had set; only unset values change. Tickets already in flight are unaffected because the Manual QA route is locked when the ticket starts.
@@ -32,6 +33,7 @@ Unreleased changes appear first and represent commits that have not yet been inc
 - Changed the Configuration model list so each row shows the catalog pretty name with the stored `provider/model` id in parentheses, so two models that share a display name can still be told apart. The closed picker still shows pretty name and provider; the main-implementer auto-included council row is unchanged.
 
 ### Fixed
+- Fixed completed bead log panels showing no entries after their logs fell outside the newest phase-history page. The panel now reads durable history scoped to the selected bead and fetches older pages as needed, while retaining the existing iteration-level filtering.
 - Replaced the project execution-lock error's internal status code and vague "busy" wording at blueprint/setup approvals, retry, continue, and pre-flight diagnostics with an actionable explanation that identifies both tickets, names the blocking workflow step, states the configured LoopTroop alpha limitation that each project may have only one active ticket in the execution band at a time, and tells the user to finish or cancel the running ticket before trying again.
 - Fixed shared YAML cleanup converting valid colon-containing list text such as `style:main` into mappings. List-item mapping repairs now require structural evidence or configured structured-list context, preserve the original key/value text, and report the formatting-only correction in artifact processing notices.
 - Fixed candidate-file audits rejecting otherwise usable structured output such as `- path:src/feature.ts`. The audit now uses the shared context-safe YAML repairs for its known `files` object shape, preserves emitted paths and reasons, records any formatting correction as an audit warning, and still falls back to including every changed file if validation remains unsuccessful.

--- a/server/log/projection.ts
+++ b/server/log/projection.ts
@@ -104,6 +104,8 @@ function ensureProjectionSchema(ticketId: string): ProjectionStorage | null {
     );
     CREATE INDEX IF NOT EXISTS idx_execution_log_projection_query
       ON execution_log_projection(ticket_id, classification, phase, phase_attempt, model_id, ordinal DESC);
+    CREATE INDEX IF NOT EXISTS idx_execution_log_projection_bead
+      ON execution_log_projection(ticket_id, channel, phase, phase_attempt, bead_id, ordinal DESC);
   `)
   initializedProjectionDatabases.add(sqlite)
   return { context, sqlite, statements: prepareProjectionStatements(sqlite) }
@@ -264,6 +266,7 @@ export interface LogPageQuery {
   scope: 'phase' | 'lifecycle'
   view: LogView
   modelId?: string
+  beadId?: string
   before?: string
   limit: number
   includeTotals?: boolean
@@ -291,6 +294,7 @@ export async function queryLogPage(ticketId: string, query: LogPageQuery) {
   const params: SQLInputValue[] = [context.localTicketId]
   if (query.scope === 'phase' && query.phase) { clauses.push('phase = ?'); params.push(query.phase) }
   if (typeof query.phaseAttempt === 'number') { clauses.push('phase_attempt = ?'); params.push(query.phaseAttempt) }
+  if (query.beadId) { clauses.push('bead_id = ?'); params.push(query.beadId) }
   if (query.view === 'debug') { clauses.push("channel = 'debug'") }
   else if (query.view === 'ai') { clauses.push("channel = 'ai'") }
   else { clauses.push("channel = 'normal'") }

--- a/server/routes/__tests__/logs.test.ts
+++ b/server/routes/__tests__/logs.test.ts
@@ -81,6 +81,31 @@ describe('ticket log projection API', () => {
     expect(commandBody.hasOlder).toBe(true)
   })
 
+  it('filters historical rows by bead id so completed bead transcripts remain addressable', async () => {
+    const { ticket } = createInitializedTestTicket(repoManager)
+    appendLogEvent(ticket.id, 'model_output', 'CODING', 'older bead output', {
+      audience: 'ai',
+      kind: 'text',
+      entryId: 'bead-1-output',
+      beadId: 'bead-1',
+      beadIteration: 1,
+    }, 'opencode', 'CODING')
+    appendLogEvent(ticket.id, 'model_output', 'CODING', 'other bead output', {
+      audience: 'ai',
+      kind: 'text',
+      entryId: 'bead-2-output',
+      beadId: 'bead-2',
+      beadIteration: 1,
+    }, 'opencode', 'CODING')
+
+    const response = await app.request(
+      `/api/tickets/${encodeURIComponent(ticket.id)}/logs?scope=phase&phase=CODING&view=ai&beadId=bead-1`,
+    )
+    expect(response.status).toBe(200)
+    expect((await response.json() as { entries: Array<{ entryId: string }> }).entries.map((entry) => entry.entryId))
+      .toEqual(['bead-1-output'])
+  })
+
   it('filters AI detail-only rows before paginating the overview', async () => {
     const { ticket } = createInitializedTestTicket(repoManager)
     for (let index = 0; index < 25; index += 1) {

--- a/server/routes/ticketHandlers/logHandlers.ts
+++ b/server/routes/ticketHandlers/logHandlers.ts
@@ -27,6 +27,7 @@ function parseQuery(c: Context, allowCursor: boolean) {
     phase: c.req.query('phase'),
     phaseAttempt,
     modelId: c.req.query('modelId'),
+    beadId: c.req.query('beadId'),
     before,
     limit,
   } as const

--- a/src/components/workspace/CodingView.tsx
+++ b/src/components/workspace/CodingView.tsx
@@ -1,6 +1,6 @@
 import { useMemo, useState, useRef, useEffect, useCallback } from 'react'
 import { useLogs } from '@/context/useLogContext'
-import type { LogEntry } from '@/context/logUtils'
+import { mergeEntriesBatch, type LogEntry } from '@/context/logUtils'
 import { useQuery } from '@tanstack/react-query'
 import { QUERY_STALE_TIME_5M, COPY_SUCCESS_DISPLAY_SHORT_MS } from '@/lib/constants'
 import { Loader2, CheckCircle2, Circle, Play, Eye, FileCode2, List, Brain, Clock, GitCommit, Tag, Link2, ArrowRight, ArrowUpToLine, ArrowDownToLine, Copy, Check, FileInput, FileOutput } from 'lucide-react'
@@ -23,6 +23,7 @@ import type { BeadNoteEntry, Ticket } from '@/hooks/useTickets'
 import { useTicketAction } from '@/hooks/useTickets'
 import { useTicketArtifacts } from '@/hooks/useTicketArtifacts'
 import { useTicketPhaseAttempts } from '@/hooks/useTicketPhaseAttempts'
+import { useTicketHistoricalLogs } from '@/hooks/useTicketHistoricalLogs'
 import { cn } from '@/lib/utils'
 import { getStatusUserLabel } from '@/lib/workflowMeta'
 import { parsePrdDocument, parsePrdDocumentContent, normalizePrdDocumentLike } from '@/lib/prdDocument'
@@ -1198,12 +1199,33 @@ export function CodingView({ ticket, readOnly }: CodingViewProps) {
     [beads, viewingBeadId],
   )
   const { prd, isLoading: prdLoading, isError: prdError } = usePrdDocument(ticket.id)
+  const historicalBeadLogs = useTicketHistoricalLogs(ticket.id, {
+    scope: 'phase',
+    phase: 'CODING',
+    phaseAttempt: logPhaseAttempt,
+    view: 'ai',
+    beadId: viewedBead?.id,
+  }, Boolean(viewedBead))
+  const {
+    entries: historicalBeadLogEntries,
+    fetchAllOlder: fetchAllHistoricalBeadLogs,
+    hasOlder: hasOlderHistoricalBeadLogs,
+    isFetchingOlder: isFetchingOlderHistoricalBeadLogs,
+  } = historicalBeadLogs
   const beadLogEntries = useMemo(() => {
     if (!viewedBead) return []
     const phaseLogs = logCtx?.getLogsForPhase(phaseForView, { phaseAttempt: logPhaseAttempt }) ?? []
-    const beadLogs = phaseLogs.filter((entry) => entry.beadId === viewedBead.id)
+    const beadLogs = mergeEntriesBatch(
+      historicalBeadLogEntries,
+      phaseLogs,
+    ).filter((entry) => entry.beadId === viewedBead.id)
     return filterBeadLogEntries(beadLogs)
-  }, [logCtx, logPhaseAttempt, phaseForView, viewedBead])
+  }, [historicalBeadLogEntries, logCtx, logPhaseAttempt, phaseForView, viewedBead])
+
+  useEffect(() => {
+    if (!viewedBead || !hasOlderHistoricalBeadLogs || isFetchingOlderHistoricalBeadLogs) return
+    void fetchAllHistoricalBeadLogs().catch(() => undefined)
+  }, [fetchAllHistoricalBeadLogs, hasOlderHistoricalBeadLogs, isFetchingOlderHistoricalBeadLogs, viewedBead])
 
   useEffect(() => {
     if (!viewedBead || !logCtx?.loadLogsForPhase) return

--- a/src/components/workspace/__tests__/CodingView.test.tsx
+++ b/src/components/workspace/__tests__/CodingView.test.tsx
@@ -659,6 +659,51 @@ describe('CodingView', () => {
     expect(screen.queryByText(/hidden debug row/)).toBeNull()
   })
 
+  it('loads a completed bead transcript from durable history after it leaves the newest phase page', async () => {
+    const historicalEntry = {
+      phase: 'CODING',
+      status: 'CODING',
+      entryId: 'historical-bead-output',
+      timestamp: '2026-01-01T00:00:01.000Z',
+      type: 'model_output',
+      content: '[MODEL] historical older output',
+      source: 'opencode',
+      audience: 'ai',
+      kind: 'text',
+      beadId: 'bead-1',
+      beadIteration: 1,
+      streaming: false,
+      op: 'finalize',
+    }
+    fetchSpy.mockImplementation((input: RequestInfo | URL) => {
+      const url = String(input)
+      if (url.includes('/logs?')) {
+        return Promise.resolve(new Response(JSON.stringify({
+          entries: [historicalEntry],
+          olderCursor: null,
+          hasOlder: false,
+        }), { status: 200, headers: { 'Content-Type': 'application/json' } }))
+      }
+      return Promise.resolve(new Response(JSON.stringify([]), { status: 200 }))
+    })
+
+    renderCoding({
+      runtime: {
+        beads: [
+          { id: 'bead-1', title: 'Historical bead', status: 'done', iteration: 1 },
+        ],
+      },
+    })
+
+    fireEvent.click(screen.getByRole('button', { name: /Historical bead/ }))
+    fireEvent.click(screen.getByRole('button', { name: 'Log' }))
+
+    expect(await screen.findByText(/historical older output/)).toBeInTheDocument()
+    expect(fetchSpy.mock.calls.some(([url]: [string, ...unknown[]]) =>
+      url.includes('/logs?scope=phase&view=ai&limit=20&phase=CODING&beadId=bead-1'),
+    )).toBe(true)
+  })
+
   it('shows bead raw tabs in order with tooltips', () => {
     renderCoding({
       runtime: {

--- a/src/hooks/__tests__/useTicketHistoricalLogs.test.tsx
+++ b/src/hooks/__tests__/useTicketHistoricalLogs.test.tsx
@@ -102,4 +102,26 @@ describe('useTicketHistoricalLogs', () => {
       expect.objectContaining({ signal: expect.any(AbortSignal) }),
     )
   })
+
+  it('includes a bead filter in durable history requests', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch')
+      .mockImplementation(() => createJsonResponse({
+        entries: [],
+        olderCursor: null,
+        hasOlder: false,
+      }))
+    const client = createTestQueryClient()
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <QueryClientProvider client={client}>{children}</QueryClientProvider>
+    )
+    renderHook(() => useTicketHistoricalLogs('ticket-1', {
+      scope: 'phase', phase: 'CODING', view: 'ai', beadId: 'bead-1',
+    }), { wrapper })
+
+    await waitFor(() => expect(fetchSpy).toHaveBeenCalled())
+    expect(fetchSpy).toHaveBeenCalledWith(
+      '/api/tickets/ticket-1/logs?scope=phase&view=ai&limit=20&phase=CODING&beadId=bead-1',
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
+    )
+  })
 })

--- a/src/hooks/useTicketHistoricalLogs.ts
+++ b/src/hooks/useTicketHistoricalLogs.ts
@@ -16,6 +16,7 @@ export interface HistoricalLogScope {
   phaseAttempt?: number
   view: HistoricalLogView
   modelId?: string
+  beadId?: string
 }
 
 interface HistoricalLogPage {
@@ -41,6 +42,7 @@ function getQuery(ticketId: string, scope: HistoricalLogScope, before?: string):
   if (scope.phase) params.set('phase', scope.phase)
   if (typeof scope.phaseAttempt === 'number') params.set('phaseAttempt', String(scope.phaseAttempt))
   if (scope.modelId) params.set('modelId', scope.modelId)
+  if (scope.beadId) params.set('beadId', scope.beadId)
   if (before) params.set('before', before)
   return `/api/tickets/${encodeURIComponent(ticketId)}/logs?${params.toString()}`
 }
@@ -66,8 +68,8 @@ function normalizePage(payload: unknown, fallbackPhase?: string): HistoricalLogP
  */
 export function useTicketHistoricalLogs(ticketId: string | undefined, scope: HistoricalLogScope, enabled = true) {
   const queryKey = useMemo(() => [
-    'ticket-log-history', ticketId ?? '__missing__', scope.scope, scope.phase ?? '', scope.phaseAttempt ?? '', scope.view, scope.modelId ?? '',
-  ], [scope.modelId, scope.phase, scope.phaseAttempt, scope.scope, scope.view, ticketId])
+    'ticket-log-history', ticketId ?? '__missing__', scope.scope, scope.phase ?? '', scope.phaseAttempt ?? '', scope.view, scope.modelId ?? '', scope.beadId ?? '',
+  ], [scope.beadId, scope.modelId, scope.phase, scope.phaseAttempt, scope.scope, scope.view, ticketId])
 
   const query = useInfiniteQuery({
     queryKey,
@@ -110,6 +112,7 @@ export function useTicketHistoricalLogs(ticketId: string | undefined, scope: His
     if (scope.phase) params.set('phase', scope.phase)
     if (typeof scope.phaseAttempt === 'number') params.set('phaseAttempt', String(scope.phaseAttempt))
     if (scope.modelId) params.set('modelId', scope.modelId)
+    if (scope.beadId) params.set('beadId', scope.beadId)
     const response = await fetch(`/api/tickets/${encodeURIComponent(ticketId)}/logs/export?${params.toString()}`, { signal })
     if (!response.ok) throw new Error(`Unable to export logs (${response.status})`)
     return response.text()


### PR DESCRIPTION
## Summary
- Load completed bead transcripts from durable projected history scoped by bead ID.
- Merge historical rows with live rows and page through older entries so prior iterations remain selectable.
- Add regression coverage for the route, history hook, and CodingView.

## Root cause
The bead pane read the in-memory phase bucket, which only contained the newest paginated history page after execution advanced. The general log view uses durable history, but the bead pane did not, so completed beads could show zero entries even though their logs were persisted.

## Verification
- `npm run lint`
- `npm run typecheck`
- `npm exec -- vitest run src/hooks/__tests__/useTicketHistoricalLogs.test.tsx src/components/workspace/__tests__/CodingView.test.tsx --project client-dom`
- `npm exec -- vitest run server/routes/__tests__/logs.test.ts --project server-integration`

No end-to-end lifecycle testing was run.