### PR TITLE
fix(ci): move the darwin-arm64 binary build off the retired macos-14 runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -679,6 +679,14 @@ jobs:
   #
   # macOS x64 is absent deliberately: Node supports single-executable
   # applications on arm64 only there, so Intel Macs keep Homebrew and npm.
+  #
+  # The macOS runner is pinned rather than floating so the OS the binary is
+  # built on is a decision rather than something that moves underneath it. It is
+  # not what decides the binary's minimum macOS version — the build copies the
+  # running Node executable and re-signs it, so that comes from Node, which
+  # `setup-node` pins. Bump this deliberately when the image is retired;
+  # `macos-14` was withdrawn on 2 Nov 2026, and a retired image fails the whole
+  # release, because `build` requires all four archives.
   binary:
     name: Binary (${{ matrix.target }})
     runs-on: ${{ matrix.os }}
@@ -689,7 +697,7 @@ jobs:
         include:
           - { os: ubuntu-latest, target: linux-x64 }
           - { os: ubuntu-24.04-arm, target: linux-arm64 }
-          - { os: macos-14, target: darwin-arm64 }
+          - { os: macos-15, target: darwin-arm64 }
           - { os: windows-latest, target: win-x64 }
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,7 +47,7 @@ on:
         default: true
       # An escape hatch for a runner-class outage, not a convenience. The
       # binaries are built on four native runners and they gate `build`, so if
-      # (say) macos-14 or ubuntu-24.04-arm is unavailable, nothing can be
+      # (say) macos-15 or ubuntu-24.04-arm is unavailable, nothing can be
       # released at all — including a security fix. This releases without them,
       # deliberately and visibly.
       #
@@ -213,7 +213,15 @@ jobs:
   # These gate `build` rather than running beside it, because the release
   # manifest has to record their checksums — WinGet's descriptor points at the
   # win-x64 archive by URL and hash, and that hash has exactly one source of
-  # truth.
+  # truth. That also means a retired runner image stops releases outright:
+  # `build` refuses to proceed without all four archives.
+  #
+  # The macOS runner is pinned rather than floating so the OS the binary is
+  # built on is a decision rather than something that moves underneath it. It is
+  # not what decides the binary's minimum macOS version — the build copies the
+  # running Node executable and re-signs it, so that comes from Node, which
+  # `setup-node` pins. Bump this deliberately when the image is retired;
+  # `macos-14` was withdrawn on 2 Nov 2026.
   binary:
     name: Binary (${{ matrix.target }})
     needs: [detect]
@@ -230,7 +238,7 @@ jobs:
         include:
           - { os: ubuntu-latest, target: linux-x64 }
           - { os: ubuntu-24.04-arm, target: linux-arm64 }
-          - { os: macos-14, target: darwin-arm64 }
+          - { os: macos-15, target: darwin-arm64 }
           - { os: windows-latest, target: win-x64 }
     steps:
       - name: Checkout

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,8 +20,10 @@ Unreleased changes appear first and represent commits that have not yet been inc
 - A backend that dies during `npm run dev` now takes the dev stack down with it, instead of leaving a frontend serving a dashboard whose every request fails.
 - The folder-ignore policy now looks like every other **Advanced** option: one row, one selector, with each choice explained on hover.
 - Completed bead transcripts now remain available in the per-bead and per-iteration log view after execution advances.
+- Releases keep working past the macOS 14 runner retirement, which would otherwise have stopped them entirely from November 2026.
 
 ### Changed
+- Moved the `darwin-arm64` standalone-binary build from the `macos-14` runner image to `macos-15`, in both CI and the release workflow. GitHub began deprecating `macos-14` on 6 July 2026 and withdrew it on 2 November 2026; because the binary jobs gate `build`, and `build` refuses to proceed without all four archives, losing that image would have stopped every release rather than just the macOS one — including a security fix. Both sites now record why the runner is pinned rather than floating: so the OS a distributed binary is built on stays a deliberate choice. It is explicitly *not* what sets the binary's minimum macOS version — the build copies the running Node executable and re-signs it, so that comes from Node, which `setup-node` already pins. The runner-outage example in the `skip_binaries` documentation was updated to match.
 - Manual QA is now enabled by default. The profile default (`PROFILE_DEFAULTS.manualQaEnabled`) flips to `true`, new database profiles seed the enabled value, and every place that fell back to "disabled" when no explicit choice existed — profile setup, project creation, ticket creation, and the draft ticket view — now falls back to the profile default. Existing profiles, projects, and tickets keep whatever they had set; only unset values change. Tickets already in flight are unaffected because the Manual QA route is locked when the ticket starts.
 
 ### Added


### PR DESCRIPTION
## Why now

GitHub began deprecating the `macos-14` runner image on **6 July 2026** and withdrew it on **2 November 2026**. Both `ci.yml` and `release.yml` pinned it for the `darwin-arm64` standalone-binary build.

This is not cosmetic. The binary jobs **gate `build`**, and `build` hard-fails unless all four archives exist — so losing that image stops **every release**, not just the macOS one, including a security fix. It fails closed rather than shipping something broken, which is the good version of the failure, but the pipeline stops either way.

## What changed

- `macos-14` → `macos-15` (also arm64) in `ci.yml` and `release.yml`.
- A comment at both sites recording **why the runner is pinned rather than floating**: so the OS a distributed binary is built on stays a deliberate choice.
- The `skip_binaries` runner-outage example no longer names a retired image.

## One thing the comment deliberately says it is *not*

The pin does **not** set the binary's minimum macOS version. `build-binary.mjs:293` copies the running Node executable and re-signs it, so the Mach-O minimum comes from **Node**, which `setup-node` already pins — as the existing job comment ("a SEA embeds the running Node") already implies.

That is written down so the next deprecation prompts a considered bump rather than a switch to floating on a rationale that does not hold. On the same reasoning `macos-latest` would also have been defensible; `macos-15` is the minimal like-for-like change from one pinned label to a supported one.

## Side effects

The `darwin-arm64` binary is built on a newer image and will differ byte-for-byte from the last release. Expected, and **not** a reproducibility failure — the `binary` job asserts that two builds *within one job* match, not that a build matches a previous release.

## Checks

lint · typecheck · full test suite (296 files, 3458 tests) · `verify:version` · YAML parse of every workflow. actionlint runs in CI's `workflows` job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)