### PR TITLE
fix(ci): read the OpenCode field the daemon persists, not the one it holds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ Unreleased changes appear first and represent commits that have not yet been inc
 
 > Changes merged since the last versioned release that have not yet shipped in a tagged version.
 
+### Fixed
+- Fixed the published install smoke reporting every channel as broken when the release was fine. Its check on how the daemon obtained OpenCode read `kind`, the discriminant of the supervisor's in-memory status, rather than `status`, which is what `describeOpenCode` writes into `daemon.json`. Nothing else in any leg failed — install, version, doctor, start, the health endpoint, the interface, the refused unauthenticated call, stop and uninstall all passed on all eight legs of the 0.5.8 release — so the only defect was the assertion. A test now pins the field against the code that renders the persisted shape, so renaming the discriminant fails in CI rather than in a post-release smoke.
+
 ## 0.5.8 (2026-08-23)
 
 

--- a/scripts/smoke-published.mjs
+++ b/scripts/smoke-published.mjs
@@ -1347,16 +1347,24 @@ async function runChannel(recipe, options) {
       const state = readJson(readFileSync(statePath, 'utf8'), 'daemon.json')
       check('daemon.json port', state?.port === port, `recorded ${state?.port}, expected ${port}`)
 
-      // `OpenCodeStatus` distinguishes a server LoopTroop started from one it
-      // found already running. Asserting only that OpenCode is reachable cannot
-      // tell those apart — an adopt leg whose pre-started server had died and
-      // been replaced by a spawned one would look identical, and the path this
-      // leg exists to cover would go untested while reporting success.
+      // Distinguishes a server LoopTroop started from one it found already
+      // running. Asserting only that OpenCode is reachable cannot tell those
+      // apart — an adopt leg whose pre-started server had died and been
+      // replaced by a spawned one would look identical, and the path that leg
+      // exists to cover would go untested while reporting success.
+      //
+      // The field is `status`, NOT `kind`. The supervisor's in-memory
+      // `OpenCodeStatus` is discriminated by `kind`, but `describeOpenCode()`
+      // maps it to `DaemonState['opencode']` on the way to the state file, and
+      // that shape uses `status` — see `describeOpenCodeForStatus` in
+      // `commands.ts`, which switches on exactly these values. Reading the
+      // in-memory type and assuming it was the persisted one made every leg
+      // fail against a perfectly good release.
       const oc = state?.opencode
       if (opencodeMode === 'adopt') {
-        check('OpenCode was adopted, not spawned', oc?.kind === 'adopted', `daemon recorded kind=${oc?.kind}`, 'adopted')
+        check('OpenCode was adopted, not spawned', oc?.status === 'adopted', `daemon recorded status=${oc?.status}`, 'adopted')
       } else if (opencodeMode !== 'mock') {
-        check('OpenCode was spawned by the daemon', oc?.kind === 'managed', `daemon recorded kind=${oc?.kind}`, 'managed')
+        check('OpenCode was spawned by the daemon', oc?.status === 'managed', `daemon recorded status=${oc?.status}`, 'managed')
         check('the managed OpenCode has a pid', Number.isInteger(oc?.pid), `pid=${oc?.pid}`, String(oc?.pid ?? ''))
         managedPid = Number.isInteger(oc?.pid) ? oc.pid : null
       }

--- a/tests/smokePublished.test.ts
+++ b/tests/smokePublished.test.ts
@@ -166,6 +166,25 @@ describe('planMatrix', () => {
     }
   })
 
+  it('reads the OpenCode field the daemon actually persists', () => {
+    // The supervisor's in-memory `OpenCodeStatus` is discriminated by `kind`;
+    // `describeOpenCode()` maps it to `DaemonState['opencode']`, which uses
+    // `status`. Reading the wrong one is invisible locally — the assertion just
+    // sees `undefined` and fails — and it failed every leg of a real release
+    // against a package that was working perfectly.
+    //
+    // Pinned against the code that renders the persisted shape, so renaming the
+    // discriminant breaks here rather than in a post-release smoke.
+    const renderer = readFileSync('server/cli/commands.ts', 'utf8')
+    const fn = renderer.slice(renderer.indexOf('export function describeOpenCodeForStatus'))
+    expect(fn.slice(0, fn.indexOf('\n}'))).toContain('opencode.status')
+
+    const driver = readFileSync('scripts/smoke-published.mjs', 'utf8')
+    expect(driver).toContain("oc?.status === 'managed'")
+    expect(driver).toContain("oc?.status === 'adopted'")
+    expect(driver).not.toContain("oc?.kind")
+  })
+
   it('honours --only', () => {
     expect(planMatrix({ tier: 'weekly', only: ['npm'] }).every((leg) => leg.channel === 'npm')).toBe(true)
     expect(planMatrix({ tier: 'weekly', only: ['nothing-by-this-name'] })).toEqual([])


### PR DESCRIPTION
All eight legs of the 0.5.8 published smoke failed with one assertion and nothing else:

```
OpenCode was spawned by the daemon: daemon recorded kind=undefined
```

## The release is fine

Every leg reported `served=0.5.8`, and install, version, doctor, start, `/api/health`, the interface and a hashed asset, the refused unauthenticated call, `status --json`, the post-start doctor, `daemon.json`, stop and uninstall **all passed on all eight**. npm ×3, both installers, Homebrew and Scoop install and run correctly. The only defect was the assertion.

## The bug

The supervisor's in-memory `OpenCodeStatus` is discriminated by `kind`. `describeOpenCode()` maps it to `DaemonState['opencode']` on the way to the state file, and *that* shape uses `status` — as `describeOpenCodeForStatus` in `commands.ts` shows, switching on exactly those values.

I read the type nearest the concept rather than the one nearest the file being read. An absent field reads as `undefined` rather than raising, so it failed as a flat assertion against a working package.

## Why it reached a release

I merged that assertion having said plainly it was the one commit with no full-matrix run behind it. It would have failed on the branch exactly as it failed here — the run was the thing that would have caught it, and I skipped it.

## The guard

A test pins the driver's field against the function that renders the persisted shape, so renaming the discriminant fails in CI rather than in a post-release smoke. Mutation-checked by reintroducing `kind` and confirming it fails.

No re-release needed — 0.5.8 is good. The smoke can be re-dispatched against it once this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)