### PR TITLE
docs: record download history charts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ Unreleased changes appear first and represent commits that have not yet been inc
 
 > Changes merged since the last versioned release that have not yet shipped in a tagged version.
 
+### Summary
+- The installation documentation now shows how downloads change over time, with source, date range, interval, metric and chart controls.
+
+### Added
+- Added download history to the installation documentation. The chart records public npm, Docker Hub and GitHub release counters every hour, can show new downloads or cumulative totals, and separates installer-script fetches from the sources included in the download total. History begins when tracking is enabled; the chart does not fill earlier periods with estimates or npm-only data.
+
 ## 0.5.9 (2026-08-26)
 
 


### PR DESCRIPTION
## Summary

- record the new hourly download-history chart in the canonical Unreleased changelog
- describe its source filters, interval and cumulative views
- state that history begins when tracking is enabled and is not filled with estimates or npm-only backfill

## Website delivery

The implementation is already published from the website repository's main branch in looptroop-ai/LoopTroop-Website@c2c98af, as required by that repository's direct-to-main workflow.

## Verification

The application repository change is documentation-only and contains no runnable command. The website implementation passed 75 tests, a clean production build, rendered-site verification, and its third-party license check.